### PR TITLE
Switch to DataStructures 0.18

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
-DataStructures = "0.17"
+DataStructures = "0.18"
 DelayDiffEq = "5"
 DiffEqBase = "6.29"
 DiffEqNoiseProcess = "5"

--- a/src/integrators/interface.jl
+++ b/src/integrators/interface.jl
@@ -47,7 +47,7 @@
       integrator.last_stepfail = false
       integrator.tprev = integrator.t
       if typeof(integrator.t)<:AbstractFloat && !isempty(integrator.opts.tstops)
-        tstop = integrator.tdir * top(integrator.opts.tstops)
+        tstop = integrator.tdir * first(integrator.opts.tstops)
         @fastmath abs(ttmp - tstop) < 10eps(integrator.t) ? (integrator.t = tstop) : (integrator.t = ttmp)
       else
         integrator.t = ttmp
@@ -58,7 +58,7 @@
   else # Non adaptive
     integrator.tprev = integrator.t
     if typeof(integrator.t)<:AbstractFloat && !isempty(integrator.opts.tstops)
-      tstop = integrator.tdir * top(integrator.opts.tstops)
+      tstop = integrator.tdir * first(integrator.opts.tstops)
       # For some reason 10eps(integrator.t) is slow here
       # TODO: Allow higher precision but profile
       @fastmath abs(ttmp - tstop) < 10eps(max(integrator.t,tstop)) ? (integrator.t = tstop) : (integrator.t = ttmp)
@@ -260,7 +260,7 @@ end
   saved, savedexactly = false, false
   !integrator.opts.save_on && return saved, savedexactly
   tdir_t = integrator.tdir * integrator.t
-  while !isempty(integrator.opts.saveat) && top(integrator.opts.saveat) <= tdir_t # Perform saveat
+  while !isempty(integrator.opts.saveat) && first(integrator.opts.saveat) <= tdir_t # Perform saveat
     integrator.saveiter += 1; saved = true
     curt = integrator.tdir * pop!(integrator.opts.saveat)
     if curt!=integrator.t # If <t, interpolate

--- a/src/integrators/utils.jl
+++ b/src/integrators/utils.jl
@@ -2,7 +2,7 @@
     tstops = integrator.opts.tstops
     if !isempty(tstops)
       tdir_t = integrator.tdir * integrator.t
-      tdir_ts_top = top(tstops)
+      tdir_ts_top = first(tstops)
       if tdir_t == tdir_ts_top
         pop!(tstops)
         integrator.just_hit_tstop = true
@@ -42,7 +42,7 @@ function handle_discontinuities!(integrator::SDDEIntegrator)
     d = pop!(integrator.opts.d_discontinuities)
     order = d.order
     while !isempty(integrator.opts.d_discontinuities) &&
-        top(integrator.opts.d_discontinuities) == integrator.tdir * integrator.t
+        first(integrator.opts.d_discontinuities) == integrator.tdir * integrator.t
 
         d2 = pop!(integrator.opts.d_discontinuities)
         order = min(order, d2.order)
@@ -55,7 +55,7 @@ function handle_discontinuities!(integrator::SDDEIntegrator)
         maxΔt = 10eps(integrator.t)
 
         while !isempty(integrator.opts.d_discontinuities) &&
-            abs(top(integrator.opts.d_discontinuities).t - integrator.tdir * integrator.t) < maxΔt
+            abs(first(integrator.opts.d_discontinuities).t - integrator.tdir * integrator.t) < maxΔt
 
             d2 = pop!(integrator.opts.d_discontinuities)
             order = min(order, d2.order)
@@ -63,7 +63,7 @@ function handle_discontinuities!(integrator::SDDEIntegrator)
 
         # also remove all corresponding time stops
         while !isempty(integrator.opts.tstops) &&
-            abs(top(integrator.opts.tstops) - integrator.tdir * integrator.t) < maxΔt
+            abs(first(integrator.opts.tstops) - integrator.tdir * integrator.t) < maxΔt
 
             pop!(integrator.opts.tstops)
         end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -438,7 +438,7 @@ end
 
 function DiffEqBase.solve!(integrator::SDDEIntegrator)
     @inbounds while !isempty(integrator.opts.tstops)
-        while integrator.tdir * integrator.t < top(integrator.opts.tstops)
+        while integrator.tdir * integrator.t < first(integrator.opts.tstops)
             loopheader!(integrator)
             if DiffEqBase.check_error!(integrator) != :Success
                 return integrator.sol


### PR DESCRIPTION
Tests will fail since, e.g., DelayDiffEq is not compatible with DataStructures 0.18 yet.