### PR TITLE
fix: fix `wrap_functions_and_history` when `g` is both iip and oop

### DIFF
--- a/src/functionwrapper.jl
+++ b/src/functionwrapper.jl
@@ -34,7 +34,7 @@ end
 (f::SDEFunctionWrapper{false})(u, p, t) = f.f(u, f.h, p, t)
 
 function wrap_functions_and_history(f::SDDEFunction, g, h)
-    gwh = SDEDiffusionTermWrapper{isinplace(g, 5), typeof(g), typeof(h)}(g, h)
+    gwh = SDEDiffusionTermWrapper{isinplace(f), typeof(g), typeof(h)}(g, h)
 
     if f.jac === nothing
         jac = nothing


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
