### PR TITLE
Fix parsing error and apply JuliaFormatter code formatting

### DIFF
--- a/src/StochasticDelayDiffEq.jl
+++ b/src/StochasticDelayDiffEq.jl
@@ -17,7 +17,7 @@ import FastPower
 import SciMLBase
 using DiffEqBase: AbstractSDDEProblem, AbstractSDDEAlgorithm, AbstractRODESolution,
                   AbstractRODEFunction, AbstractSDEIntegrator, AbstractSDDEIntegrator,
-                  DEIntegrator, DEAlgorithm, AbstractRODEAlgorithm, AbstractSDEAlgorithm
+                  DEIntegrator, DEAlgorithm, AbstractRODEAlgorithm, AbstractSDEAlgorithm, @..
 
 import DelayDiffEq: constant_extrapolant!, constant_extrapolant,
                     AbstractMethodOfStepsAlgorithm, iscomposite, MethodOfSteps

--- a/src/functionwrapper.jl
+++ b/src/functionwrapper.jl
@@ -8,8 +8,9 @@ end
 (g::SDEDiffusionTermWrapper{true})(du, u, p, t) = g.g(du, u, g.h, p, t)
 (g::SDEDiffusionTermWrapper{false})(u, p, t) = g.g(u, g.h, p, t)
 
-struct SDEFunctionWrapper{iip, F, G, H, TMM, Ta, Tt, TJ, JVP, VJP, JP, SP, TW, TWt, TPJ, GG,
-                          TCV, ID, S} <: DiffEqBase.AbstractRODEFunction{iip}
+struct SDEFunctionWrapper{
+    iip, F, G, H, TMM, Ta, Tt, TJ, JVP, VJP, JP, SP, TW, TWt, TPJ, GG,
+    TCV, ID, S} <: DiffEqBase.AbstractRODEFunction{iip}
     f::F
     g::G
     h::H
@@ -51,13 +52,13 @@ function wrap_functions_and_history(f::SDDEFunction, g, h)
     end
 
     SDEFunctionWrapper{isinplace(f), typeof(f.f), typeof(gwh), typeof(h),
-                       typeof(f.mass_matrix),
-                       typeof(f.analytic), typeof(f.tgrad), typeof(jac), typeof(f.jvp),
-                       typeof(f.vjp), typeof(f.jac_prototype), typeof(f.sparsity),
-                       typeof(f.Wfact), typeof(f.Wfact_t), typeof(f.paramjac),
-                       typeof(f.ggprime), typeof(f.colorvec), typeof(f.initialization_data),
-                       typeof(f.sys)}(f.f, gwh, h, f.mass_matrix, f.analytic, f.tgrad, jac,
-                       f.jvp, f.vjp, f.jac_prototype, f.sparsity, f.Wfact, f.Wfact_t, f.paramjac,
-                       f.ggprime, f.colorvec, f.initialization_data, f.sys),
+        typeof(f.mass_matrix),
+        typeof(f.analytic), typeof(f.tgrad), typeof(jac), typeof(f.jvp),
+        typeof(f.vjp), typeof(f.jac_prototype), typeof(f.sparsity),
+        typeof(f.Wfact), typeof(f.Wfact_t), typeof(f.paramjac),
+        typeof(f.ggprime), typeof(f.colorvec), typeof(f.initialization_data),
+        typeof(f.sys)}(f.f, gwh, h, f.mass_matrix, f.analytic, f.tgrad, jac,
+        f.jvp, f.vjp, f.jac_prototype, f.sparsity, f.Wfact, f.Wfact_t, f.paramjac,
+        f.ggprime, f.colorvec, f.initialization_data, f.sys),
     gwh
 end

--- a/src/integrators/interface.jl
+++ b/src/integrators/interface.jl
@@ -40,8 +40,9 @@ end
     elseif integrator.opts.adaptive
         stepsize_controller!(integrator, getalg(integrator.alg))
         integrator.isout = integrator.opts.isoutofdomain(integrator.u, integrator.p, ttmp)
-        integrator.accept_step = (!integrator.isout && accept_step_controller(integrator,
-                                                         integrator.opts.controller)) ||
+        integrator.accept_step = (!integrator.isout &&
+                                  accept_step_controller(integrator,
+            integrator.opts.controller)) ||
                                  (integrator.opts.force_dtmin &&
                                   integrator.dt <= integrator.opts.dtmin)
         if integrator.accept_step # Accepted
@@ -76,11 +77,11 @@ end
     end
     if integrator.opts.progress && integrator.iter % integrator.opts.progress_steps == 0
         @logmsg(-1,
-                integrator.opts.progress_name,
-                _id=:StochasticDelayDiffEq,
-                message=integrator.opts.progress_message(integrator.dt, integrator.u,
-                                                         integrator.p, integrator.t),
-                progress=integrator.t / integrator.sol.prob.tspan[2])
+            integrator.opts.progress_name,
+            _id=:StochasticDelayDiffEq,
+            message=integrator.opts.progress_message(integrator.dt, integrator.u,
+                integrator.p, integrator.t),
+            progress=integrator.t/integrator.sol.prob.tspan[2])
     end
 end
 
@@ -90,11 +91,11 @@ end
     resize!(integrator.sol.u, integrator.saveiter)
     if integrator.opts.progress
         @logmsg(-1,
-                integrator.opts.progress_name,
-                _id=:StochasticDiffEq,
-                message=integrator.opts.progress_message(integrator.dt, integrator.u,
-                                                         integrator.p, integrator.t),
-                progress="done")
+            integrator.opts.progress_name,
+            _id=:StochasticDiffEq,
+            message=integrator.opts.progress_message(integrator.dt, integrator.u,
+                integrator.p, integrator.t),
+            progress="done")
     end
     return nothing
 end
@@ -114,20 +115,20 @@ function DiffEqBase.auto_dt_reset!(integrator::SDDEIntegrator)
 
     # determine initial time step
     sde_prob = SDEProblem(f, g, prob.u0, prob.tspan, prob.p;
-                          noise_rate_prototype = prob.noise_rate_prototype,
-                          noise = prob.noise,
-                          seed = prob.seed,
-                          prob.kwargs...)
+        noise_rate_prototype = prob.noise_rate_prototype,
+        noise = prob.noise,
+        seed = prob.seed,
+        prob.kwargs...)
     integrator.dt = StochasticDiffEq.sde_determine_initdt(integrator.u, integrator.t,
-                                                          integrator.tdir,
-                                                          integrator.opts.dtmax,
-                                                          integrator.opts.abstol,
-                                                          integrator.opts.reltol,
-                                                          integrator.opts.internalnorm,
-                                                          sde_prob,
-                                                          StochasticDiffEq.get_current_alg_order(getalg(integrator.alg),
-                                                                                                 integrator.cache),
-                                                          integrator)
+        integrator.tdir,
+        integrator.opts.dtmax,
+        integrator.opts.abstol,
+        integrator.opts.reltol,
+        integrator.opts.internalnorm,
+        sde_prob,
+        StochasticDiffEq.get_current_alg_order(getalg(integrator.alg),
+            integrator.cache),
+        integrator)
     # update statistics
     # destats.nf += 2
     # destats.nf2 += 2
@@ -137,19 +138,19 @@ end
 
 DiffEqBase.has_reinit(integrator::SDDEIntegrator) = false # TODO true - synchronize with DDE!
 function DiffEqBase.reinit!(integrator::SDDEIntegrator, u0 = integrator.sol.prob.u0;
-                            t0 = integrator.sol.prob.tspan[1],
-                            tf = integrator.sol.prob.tspan[2],
-                            erase_sol = true,
-                            tstops = integrator.opts.tstops_cache,
-                            saveat = integrator.opts.saveat_cache,
-                            d_discontinuities = integrator.opts.d_discontinuities_cache,
-                            order_discontinuity_t0 = t0 == integrator.sol.prob.tspan[1] &&
-                                u0 == integrator.sol.prob.u0 ?
-                                                     integrator.order_discontinuity_t0 : 0,
-                            reinit_cache = true, reinit_callbacks = true,
-                            initialize_save = true,
-                            reset_dt = (integrator.dtcache == zero(integrator.dt)) &&
-                                integrator.opts.adaptive)
+        t0 = integrator.sol.prob.tspan[1],
+        tf = integrator.sol.prob.tspan[2],
+        erase_sol = true,
+        tstops = integrator.opts.tstops_cache,
+        saveat = integrator.opts.saveat_cache,
+        d_discontinuities = integrator.opts.d_discontinuities_cache,
+        order_discontinuity_t0 = t0 == integrator.sol.prob.tspan[1] &&
+                                 u0 == integrator.sol.prob.u0 ?
+                                 integrator.order_discontinuity_t0 : 0,
+        reinit_cache = true, reinit_callbacks = true,
+        initialize_save = true,
+        reset_dt = (integrator.dtcache == zero(integrator.dt)) &&
+                   integrator.opts.adaptive)
     if DiffEqBase.isinplace(integrator.sol.prob)
         recursivecopy!(integrator.u, u0)
         recursivecopy!(integrator.uprev, integrator.u)
@@ -163,15 +164,16 @@ function DiffEqBase.reinit!(integrator::SDDEIntegrator, u0 = integrator.sol.prob
 
     tType = typeof(integrator.t)
     maximum_order = StochasticDiffEq.alg_order(getalg(integrator.alg))
-    tstops_internal, saveat_internal, d_discontinuities_internal = tstop_saveat_disc_handling(tstops,
-                                                                                              saveat,
-                                                                                              d_discontinuities,
-                                                                                              (tType(t0),
-                                                                                               tType(tf)),
-                                                                                              order_discontinuity_t0,
-                                                                                              maximum_order,
-                                                                                              integrator.sol.prob.constant_lags,
-                                                                                              integrator.sol.prob.neutral)
+    tstops_internal, saveat_internal,
+    d_discontinuities_internal = tstop_saveat_disc_handling(tstops,
+        saveat,
+        d_discontinuities,
+        (tType(t0),
+            tType(tf)),
+        order_discontinuity_t0,
+        maximum_order,
+        integrator.sol.prob.constant_lags,
+        integrator.sol.prob.neutral)
 
     integrator.opts.tstops = tstops_internal
     integrator.opts.saveat = saveat_internal
@@ -197,9 +199,10 @@ function DiffEqBase.reinit!(integrator::SDDEIntegrator, u0 = integrator.sol.prob
 
         if order_discontinuity_t0 ≤ maximum_order
             resize!(integrator.tracked_discontinuities, 1)
-            integrator.tracked_discontinuities[1] = Discontinuity(integrator.tdir *
-                                                                  integrator.t,
-                                                                  Rational{Int}(order_discontinuity_t0))
+            integrator.tracked_discontinuities[1] = Discontinuity(
+                integrator.tdir *
+                integrator.t,
+                Rational{Int}(order_discontinuity_t0))
         else
             resize!(integrator.tracked_discontinuities, 0)
         end
@@ -235,7 +238,7 @@ end
 end
 
 @inline function DiffEqBase.get_du!(out, integrator::SDDEIntegrator)
-    DiffEqBase.@.. out = (integrator.u - integrator.uprev) / integrator.dt
+    @.. out = (integrator.u - integrator.uprev) / integrator.dt
 end
 
 @inline function DiffEqBase.add_tstop!(integrator::SDDEIntegrator, t)
@@ -245,11 +248,11 @@ end
 end
 
 function DiffEqBase.change_t_via_interpolation!(integrator::SDDEIntegrator, t,
-                                                modify_save_endpoint::Type{Val{T}} = Val{
-                                                                                         false
-                                                                                         }) where {
-                                                                                                   T
-                                                                                                   }
+        modify_save_endpoint::Type{Val{T}} = Val{
+            false
+        }) where {
+        T
+}
     StochasticDiffEq.change_t_via_interpolation!(integrator, t, modify_save_endpoint)
 end
 
@@ -261,15 +264,16 @@ function StochasticDiffEq.handle_callback_modifiers!(integrator::SDDEIntegrator)
             oldrate = integrator.P.cache.currate
             integrator.P.cache.rate(oldrate, integrator.u, integrator.p, integrator.t)
         else
-            integrator.P.cache.currate = integrator.P.cache.rate(integrator.u, integrator.p,
-                                                                 integrator.t)
+            integrator.P.cache.currate = integrator.P.cache.rate(
+                integrator.u, integrator.p,
+                integrator.t)
         end
     end
 
     # update heap of discontinuities
     # discontinuity is assumed to be of order 0, i.e. solution x is discontinuous
     push!(integrator.opts.d_discontinuities,
-          Discontinuity(integrator.tdir * integrator.t, 0 // 1))
+        Discontinuity(integrator.tdir * integrator.t, 0 // 1))
 end
 
 function DiffEqBase.u_modified!(integrator::SDDEIntegrator, bool::Bool)
@@ -283,7 +287,7 @@ function DiffEqBase.set_proposed_dt!(integrator::SDDEIntegrator, dt::Number)
 end
 
 function DiffEqBase.set_proposed_dt!(integrator::SDDEIntegrator,
-                                     integrator2::SDDEIntegrator)
+        integrator2::SDDEIntegrator)
     integrator.dtpropose = integrator2.dtpropose
     integrator.qold = integrator2.qold
 end
@@ -296,7 +300,7 @@ end
             copyat_or_push!(integrator.sol.u, integrator.saveiter, integrator.u)
         else
             copyat_or_push!(integrator.sol.u, integrator.saveiter,
-                            integrator.u[integrator.opts.save_idxs], Val{false})
+                integrator.u[integrator.opts.save_idxs], Val{false})
         end
     end
 
@@ -313,7 +317,7 @@ function DiffEqBase.postamble!(integrator::SDDEIntegrator)
 end
 
 @inline function DiffEqBase.savevalues!(integrator::SDDEIntegrator,
-                                        force_save = false)::Tuple{Bool, Bool}
+        force_save = false)::Tuple{Bool, Bool}
     saved, savedexactly = false, false
     !integrator.opts.save_on && return saved, savedexactly
     tdir_t = integrator.tdir * integrator.t
@@ -323,14 +327,15 @@ end
         curt = integrator.tdir * pop!(integrator.opts.saveat)
         if curt != integrator.t # If <t, interpolate
             Θ = (curt - integrator.tprev) / integrator.dt
-            val = StochasticDiffEq.sde_interpolant(Θ, integrator, integrator.opts.save_idxs,
-                                                   Val{0}) # out of place, but force copy later
+            val = StochasticDiffEq.sde_interpolant(
+                Θ, integrator, integrator.opts.save_idxs,
+                Val{0}) # out of place, but force copy later
             save_val = val
             copyat_or_push!(integrator.sol.t, integrator.saveiter, curt)
             copyat_or_push!(integrator.sol.u, integrator.saveiter, save_val, Val{false})
             if integrator.alg isa StochasticDiffEq.StochasticDiffEqCompositeAlgorithm
                 copyat_or_push!(integrator.sol.alg_choice, integrator.saveiter,
-                                integrator.cache.current)
+                    integrator.cache.current)
             end
         else # ==t, just save
             savedexactly = true
@@ -339,13 +344,13 @@ end
                 copyat_or_push!(integrator.sol.u, integrator.saveiter, integrator.u)
             else
                 copyat_or_push!(integrator.sol.u, integrator.saveiter,
-                                integrator.u[integrator.opts.save_idxs], Val{false})
+                    integrator.u[integrator.opts.save_idxs], Val{false})
             end
             if integrator.alg isa
                Union{StochasticDiffEq.StochasticDiffEqCompositeAlgorithm,
-                     StochasticDiffEq.StochasticDiffEqRODECompositeAlgorithm}
+                StochasticDiffEq.StochasticDiffEqRODECompositeAlgorithm}
                 copyat_or_push!(integrator.sol.alg_choice, integrator.saveiter,
-                                integrator.cache.current)
+                    integrator.cache.current)
             end
         end
     end
@@ -356,14 +361,14 @@ end
             copyat_or_push!(integrator.sol.u, integrator.saveiter, integrator.u)
         else
             copyat_or_push!(integrator.sol.u, integrator.saveiter,
-                            integrator.u[integrator.opts.save_idxs], Val{false})
+                integrator.u[integrator.opts.save_idxs], Val{false})
         end
         copyat_or_push!(integrator.sol.t, integrator.saveiter, integrator.t)
         if integrator.alg isa
            Union{StochasticDiffEq.StochasticDiffEqCompositeAlgorithm,
-                 StochasticDiffEq.StochasticDiffEqRODECompositeAlgorithm}
+            StochasticDiffEq.StochasticDiffEqRODECompositeAlgorithm}
             copyat_or_push!(integrator.sol.alg_choice, integrator.saveiter,
-                            integrator.cache.current)
+                integrator.cache.current)
         end
     end
     return saved, savedexactly
@@ -377,7 +382,7 @@ end
 end
 
 @inline function DiffEqNoiseProcess.reject_step!(integrator::SDDEIntegrator,
-                                                 dtnew = integrator.dtnew)
+        dtnew = integrator.dtnew)
     !isnothing(integrator.W) &&
         reject_step!(integrator.W, dtnew, integrator.u, integrator.p)
     !isnothing(integrator.P) &&
@@ -401,20 +406,20 @@ end
 end
 # avoid method ambiguity
 for typ in (StochasticDiffEq.StochasticDiffEqAlgorithm,
-            StochasticDiffEq.StochasticDiffEqNewtonAdaptiveAlgorithm)
+    StochasticDiffEq.StochasticDiffEqNewtonAdaptiveAlgorithm)
     @eval @inline function DiffEqBase.get_tmp_cache(integrator::SDDEIntegrator, alg::$typ,
-                                                    cache::StochasticDiffEq.StochasticDiffEqConstantCache)
+            cache::StochasticDiffEq.StochasticDiffEqConstantCache)
         nothing
     end
 end
 @inline DiffEqBase.get_tmp_cache(integrator::SDDEIntegrator, alg, cache) = (cache.tmp,)
 @inline function DiffEqBase.get_tmp_cache(integrator::SDDEIntegrator,
-                                          alg::StochasticDiffEq.StochasticDiffEqNewtonAdaptiveAlgorithm,
-                                          cache)
+        alg::StochasticDiffEq.StochasticDiffEqNewtonAdaptiveAlgorithm,
+        cache)
     (cache.nlsolver.tmp, cache.nlsolver.ztmp)
 end
 @inline function DiffEqBase.get_tmp_cache(integrator::SDDEIntegrator,
-                                          alg::StochasticDiffEq.StochasticCompositeAlgorithm,
-                                          cache)
+        alg::StochasticDiffEq.StochasticCompositeAlgorithm,
+        cache)
     get_tmp_cache(integrator, alg.algs[1], cache.caches[1])
 end

--- a/src/integrators/type.jl
+++ b/src/integrators/type.jl
@@ -18,15 +18,15 @@ function (integrator::HistorySDEIntegrator)(t, deriv::Type = Val{0}; idxs = noth
 end
 
 function (integrator::HistorySDEIntegrator)(val::AbstractArray,
-                                            t::Union{Number, AbstractArray},
-                                            deriv::Type = Val{0}; idxs = nothing)
+        t::Union{Number, AbstractArray},
+        deriv::Type = Val{0}; idxs = nothing)
     StochasticDiffEq.current_interpolant!(val, t, integrator, idxs, deriv)
 end
 
 mutable struct SDDEIntegrator{algType, IIP, uType, uEltype, tType, P, eigenType,
-                              tTypeNoUnits, uEltypeNoUnits, randType, randType2, rateType,
-                              solType, cacheType, F, G, F6, OType, noiseType,
-                              EventErrorType, CallbackCacheType, H, IType, IA} <:
+    tTypeNoUnits, uEltypeNoUnits, randType, randType2, rateType,
+    solType, cacheType, F, G, F6, OType, noiseType,
+    EventErrorType, CallbackCacheType, H, IType, IA} <:
                AbstractSDDEIntegrator{algType, IIP, uType, tType}
     f::F
     g::G
@@ -89,6 +89,6 @@ function (integrator::SDDEIntegrator)(t, deriv::Type = Val{0}; idxs = nothing)
 end
 
 function (integrator::SDDEIntegrator)(val::AbstractArray, t::Union{Number, AbstractArray},
-                                      deriv::Type = Val{0}; idxs = nothing)
+        deriv::Type = Val{0}; idxs = nothing)
     StochasticDiffEq.current_interpolant!(val, t, integrator, idxs, deriv)
 end

--- a/src/integrators/utils.jl
+++ b/src/integrators/utils.jl
@@ -9,7 +9,7 @@
         elseif tdir_t > tdir_ts_top
             if !integrator.dtchangeable
                 change_t_via_interpolation!(integrator, integrator.tdir * pop!(tstops),
-                                            Val{true})
+                    Val{true})
                 integrator.just_hit_tstop = true
             else
                 error("Something went wrong. Integrator stepped past tstops but the algorithm was dtchangeable. Please report this error.")
@@ -55,7 +55,8 @@ function handle_discontinuities!(integrator::SDDEIntegrator)
         maxΔt = 10eps(integrator.t)
 
         while !isempty(integrator.opts.d_discontinuities) &&
-            abs(first(integrator.opts.d_discontinuities).t - integrator.tdir * integrator.t) <
+            abs(first(integrator.opts.d_discontinuities).t -
+                integrator.tdir * integrator.t) <
             maxΔt
             d2 = pop!(integrator.opts.d_discontinuities)
             order = min(order, d2.order)

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -1,73 +1,73 @@
 function DiffEqBase.__solve(prob::AbstractSDDEProblem, # TODO: DiffEqBase.AbstractSDDEProblem
-                            alg::AbstractSDEAlgorithm, args...; # TODO: Method of steps???
-                            kwargs...)
+        alg::AbstractSDEAlgorithm, args...; # TODO: Method of steps???
+        kwargs...)
     integrator = DiffEqBase.__init(prob, alg, args...; kwargs...)
     DiffEqBase.solve!(integrator)
     integrator.sol
 end
 
 function DiffEqBase.__init(prob::AbstractSDDEProblem,# TODO DiffEqBasee.AbstractSDDEProblem
-                           alg::Union{AbstractRODEAlgorithm, AbstractSDEAlgorithm},
-                           timeseries_init = typeof(prob.u0)[],
-                           ts_init = eltype(prob.tspan)[],
-                           ks_init = nothing,
-                           recompile::Type{Val{recompile_flag}} = Val{true};
-                           saveat = eltype(prob.tspan)[],
-                           tstops = eltype(prob.tspan)[],
-                           d_discontinuities = Discontinuity{eltype(prob.tspan),
-                                                             Rational{Int}}[],
-                           save_idxs = nothing,
-                           save_everystep = isempty(saveat),
-                           save_noise = save_everystep && (prob.f isa Tuple ?
-                            DiffEqBase.has_analytic(prob.f[1]) :
-                            DiffEqBase.has_analytic(prob.f)),
-                           save_on = true,
-                           save_start = save_everystep || isempty(saveat) ||
-                                            saveat isa Number ? true :
-                                        prob.tspan[1] in saveat,
-                           save_end = nothing,
-                           callback = nothing,
-                           dense = save_everystep && isempty(saveat),
-                           calck = (!isempty(setdiff(saveat, tstops)) || dense),
-                           dt = eltype(prob.tspan)(0),
-                           adaptive = StochasticDiffEq.isadaptive(getalg(alg)),
-                           gamma = 9 // 10, # TODO gamma_default(alg.alg) ?
-                           abstol = nothing,
-                           reltol = nothing,
-                           qmax = StochasticDiffEq.qmax_default(getalg(alg)),
-                           qmin = StochasticDiffEq.qmin_default(getalg(alg)),
-                           qsteady_min = StochasticDiffEq.qsteady_min_default(alg),
-                           qsteady_max = StochasticDiffEq.qsteady_max_default(alg),
-                           qoldinit = 1 // 10^4, fullnormalize = true,
-                           controller = nothing,
-                           failfactor = 2,
-                           beta2 = nothing,
-                           beta1 = nothing,
-                           delta = StochasticDiffEq.delta_default(getalg(alg)),
-                           maxiters = adaptive ? 1000000 : typemax(Int),
-                           dtmax = eltype(prob.tspan)((prob.tspan[end] - prob.tspan[1])),
-                           dtmin = typeof(one(eltype(prob.tspan))) <: AbstractFloat ?
-                                   eps(eltype(prob.tspan)) :
-                                   typeof(one(eltype(prob.tspan))) <: Integer ? 0 :
-                                   eltype(prob.tspan)(1 // 10^(10)),
-                           internalnorm = DiffEqBase.ODE_DEFAULT_NORM,
-                           isoutofdomain = DiffEqBase.ODE_DEFAULT_ISOUTOFDOMAIN,
-                           unstable_check = DiffEqBase.ODE_DEFAULT_UNSTABLE_CHECK,
-                           verbose = true, force_dtmin = false,
-                           timeseries_errors = true, dense_errors = false,
-                           advance_to_tstop = false, stop_at_next_tstop = false,
-                           initialize_save = true,
-                           progress = false, progress_steps = 1000, progress_name = "SDDE",
-                           progress_id=gensym("StochasticDiffEq"),
-                           progress_message = DiffEqBase.ODE_DEFAULT_PROG_MESSAGE,
-                           userdata = nothing,
-                           initialize_integrator = true,
-                           seed = UInt64(0), alias_u0 = false,
-                           #  Keywords for Delay problems (from DDE)
-                           discontinuity_interp_points::Int = 10,
-                           discontinuity_abstol = eltype(prob.tspan)(1 // Int64(10)^12),
-                           discontinuity_reltol = 0,
-                           initializealg = StochasticDiffEq.OrdinaryDiffEqCore.DefaultInit(), kwargs...) where {recompile_flag}
+        alg::Union{AbstractRODEAlgorithm, AbstractSDEAlgorithm},
+        timeseries_init = typeof(prob.u0)[],
+        ts_init = eltype(prob.tspan)[],
+        ks_init = nothing,
+        recompile::Type{Val{recompile_flag}} = Val{true};
+        saveat = eltype(prob.tspan)[],
+        tstops = eltype(prob.tspan)[],
+        d_discontinuities = Discontinuity{eltype(prob.tspan),
+            Rational{Int}}[],
+        save_idxs = nothing,
+        save_everystep = isempty(saveat),
+        save_noise = save_everystep && (prob.f isa Tuple ?
+                      DiffEqBase.has_analytic(prob.f[1]) :
+                      DiffEqBase.has_analytic(prob.f)),
+        save_on = true,
+        save_start = save_everystep || isempty(saveat) ||
+                     saveat isa Number ? true :
+                     prob.tspan[1] in saveat,
+        save_end = nothing,
+        callback = nothing,
+        dense = save_everystep && isempty(saveat),
+        calck = (!isempty(setdiff(saveat, tstops)) || dense),
+        dt = eltype(prob.tspan)(0),
+        adaptive = StochasticDiffEq.isadaptive(getalg(alg)),
+        gamma = 9 // 10, # TODO gamma_default(alg.alg) ?
+        abstol = nothing,
+        reltol = nothing,
+        qmax = StochasticDiffEq.qmax_default(getalg(alg)),
+        qmin = StochasticDiffEq.qmin_default(getalg(alg)),
+        qsteady_min = StochasticDiffEq.qsteady_min_default(alg),
+        qsteady_max = StochasticDiffEq.qsteady_max_default(alg),
+        qoldinit = 1 // 10^4, fullnormalize = true,
+        controller = nothing,
+        failfactor = 2,
+        beta2 = nothing,
+        beta1 = nothing,
+        delta = StochasticDiffEq.delta_default(getalg(alg)),
+        maxiters = adaptive ? 1000000 : typemax(Int),
+        dtmax = eltype(prob.tspan)((prob.tspan[end] - prob.tspan[1])),
+        dtmin = typeof(one(eltype(prob.tspan))) <: AbstractFloat ?
+                eps(eltype(prob.tspan)) :
+                typeof(one(eltype(prob.tspan))) <: Integer ? 0 :
+                eltype(prob.tspan)(1 // 10^(10)),
+        internalnorm = DiffEqBase.ODE_DEFAULT_NORM,
+        isoutofdomain = DiffEqBase.ODE_DEFAULT_ISOUTOFDOMAIN,
+        unstable_check = DiffEqBase.ODE_DEFAULT_UNSTABLE_CHECK,
+        verbose = true, force_dtmin = false,
+        timeseries_errors = true, dense_errors = false,
+        advance_to_tstop = false, stop_at_next_tstop = false,
+        initialize_save = true,
+        progress = false, progress_steps = 1000, progress_name = "SDDE",
+        progress_id = gensym("StochasticDiffEq"),
+        progress_message = DiffEqBase.ODE_DEFAULT_PROG_MESSAGE,
+        userdata = nothing,
+        initialize_integrator = true,
+        seed = UInt64(0), alias_u0 = false,
+        #  Keywords for Delay problems (from DDE)
+        discontinuity_interp_points::Int = 10,
+        discontinuity_abstol = eltype(prob.tspan)(1 // Int64(10)^12),
+        discontinuity_reltol = 0,
+        initializealg = StochasticDiffEq.OrdinaryDiffEqCore.DefaultInit(), kwargs...) where {recompile_flag}
 
     # alg = getalg(alg0);
     if prob.f isa Tuple
@@ -101,7 +101,7 @@ function DiffEqBase.__init(prob::AbstractSDDEProblem,# TODO DiffEqBasee.Abstract
         @warn "minimal_solution is ignored"
     end
 
-    progress && @logmsg(LogLevel(-1),progress_name,_id=progress_id,progress=0)
+    progress && @logmsg(LogLevel(-1), progress_name, _id=progress_id, progress=0)
 
     tType = eltype(prob.tspan)
     noise = prob.noise
@@ -140,7 +140,7 @@ function DiffEqBase.__init(prob::AbstractSDDEProblem,# TODO DiffEqBasee.Abstract
     if abstol === nothing
         if uBottomEltypeNoUnits == uBottomEltype
             abstol_internal = real(convert(uBottomEltype,
-                                           oneunit(uBottomEltype) * 1 // 10^2))
+                oneunit(uBottomEltype) * 1 // 10^2))
         else
             abstol_internal = real.(oneunit.(u) .* 1 // 10^2)
         end
@@ -151,7 +151,7 @@ function DiffEqBase.__init(prob::AbstractSDDEProblem,# TODO DiffEqBasee.Abstract
     if reltol === nothing
         if uBottomEltypeNoUnits == uBottomEltype
             reltol_internal = real(convert(uBottomEltype,
-                                           oneunit(uBottomEltype) * 1 // 10^2))
+                oneunit(uBottomEltype) * 1 // 10^2))
         else
             reltol_internal = real.(oneunit.(u) .* 1 // 10^2)
         end
@@ -165,8 +165,8 @@ function DiffEqBase.__init(prob::AbstractSDDEProblem,# TODO DiffEqBasee.Abstract
             rate_prototype = recursivecopy(u)
         else
             rate_prototype = similar(u,
-                                     typeof.(oneunit.(recursive_bottom_eltype.(u.x)) ./
-                                             oneunit(tType))...)
+                typeof.(oneunit.(recursive_bottom_eltype.(u.x)) ./
+                        oneunit(tType))...)
         end
     else
         if uBottomEltypeNoUnits == uBottomEltype
@@ -226,19 +226,20 @@ function DiffEqBase.__init(prob::AbstractSDDEProblem,# TODO DiffEqBasee.Abstract
     #   tstop_saveat_disc_handling(tstops, saveat, d_discontinuities, tspan) # TODO add delays to discontinuities
     # retrieve time stops, time points at which solutions is saved, and discontinuities
     maximum_order = StochasticDiffEq.alg_order(getalg(alg))
-    tstops_internal, saveat_internal, d_discontinuities_internal = tstop_saveat_disc_handling(tstops,
-                                                                                              saveat,
-                                                                                              d_discontinuities,
-                                                                                              tspan,
-                                                                                              order_discontinuity_t0,
-                                                                                              maximum_order,
-                                                                                              constant_lags,
-                                                                                              neutral)
+    tstops_internal, saveat_internal,
+    d_discontinuities_internal = tstop_saveat_disc_handling(tstops,
+        saveat,
+        d_discontinuities,
+        tspan,
+        order_discontinuity_t0,
+        maximum_order,
+        constant_lags,
+        neutral)
 
     tracked_discontinuities = Discontinuity{tType, Rational{Int}}[]
     if order_discontinuity_t0 ≤ maximum_order
         push!(tracked_discontinuities,
-              Discontinuity(tdir * t, Rational{Int}(order_discontinuity_t0)))
+            Discontinuity(tdir * t, Rational{Int}(order_discontinuity_t0)))
     end
 
     callbacks_internal = CallbackSet(callback)
@@ -246,7 +247,7 @@ function DiffEqBase.__init(prob::AbstractSDDEProblem,# TODO DiffEqBasee.Abstract
     max_len_cb = DiffEqBase.max_vector_callback_length(callbacks_internal)
     if max_len_cb isa DiffEqBase.VectorContinuousCallback
         callback_cache = DiffEqBase.CallbackCache(max_len_cb.len, uBottomEltype,
-                                                  uBottomEltype)
+            uBottomEltype)
     else
         callback_cache = nothing
     end
@@ -280,26 +281,26 @@ function DiffEqBase.__init(prob::AbstractSDDEProblem,# TODO DiffEqBasee.Abstract
         if isinplace(prob)
             if StochasticDiffEq.alg_needs_extra_process(getalg(alg))
                 W = WienerProcess!(t, rand_prototype, rand_prototype,
-                                   save_everystep = save_noise,
-                                   rswm = rswm,
-                                   rng = Xorshifts.Xoroshiro128Plus(_seed))
+                    save_everystep = save_noise,
+                    rswm = rswm,
+                    rng = Xorshifts.Xoroshiro128Plus(_seed))
             else
                 W = WienerProcess!(t, rand_prototype,
-                                   save_everystep = save_noise,
-                                   rswm = rswm,
-                                   rng = Xorshifts.Xoroshiro128Plus(_seed))
+                    save_everystep = save_noise,
+                    rswm = rswm,
+                    rng = Xorshifts.Xoroshiro128Plus(_seed))
             end
         else
             if StochasticDiffEq.alg_needs_extra_process(getalg(alg))
                 W = WienerProcess(t, rand_prototype, rand_prototype,
-                                  save_everystep = save_noise,
-                                  rswm = rswm,
-                                  rng = Xorshifts.Xoroshiro128Plus(_seed))
+                    save_everystep = save_noise,
+                    rswm = rswm,
+                    rng = Xorshifts.Xoroshiro128Plus(_seed))
             else
                 W = WienerProcess(t, rand_prototype,
-                                  save_everystep = save_noise,
-                                  rswm = rswm,
-                                  rng = Xorshifts.Xoroshiro128Plus(_seed))
+                    save_everystep = save_noise,
+                    rswm = rswm,
+                    rng = Xorshifts.Xoroshiro128Plus(_seed))
             end
         end
     else
@@ -317,11 +318,13 @@ function DiffEqBase.__init(prob::AbstractSDDEProblem,# TODO DiffEqBasee.Abstract
         end
     end
 
-    save_idxs, saved_subsystem = SciMLBase.get_save_idxs_and_saved_subsystem(prob, save_idxs)
-    ts, timeseries, saveiter = solution_arrays(u, tspan, rate_prototype,
-                                               timeseries_init = timeseries_init,
-                                               ts_init = ts_init, save_idxs = save_idxs,
-                                               save_start = save_start)
+    save_idxs,
+    saved_subsystem = SciMLBase.get_save_idxs_and_saved_subsystem(prob, save_idxs)
+    ts, timeseries,
+    saveiter = solution_arrays(u, tspan, rate_prototype,
+        timeseries_init = timeseries_init,
+        ts_init = ts_init, save_idxs = save_idxs,
+        save_start = save_start)
 
     if !adaptive && save_everystep && tspan[2] - tspan[1] != Inf
         iszero(dt) ? steps = length(tstops) :
@@ -347,22 +350,22 @@ function DiffEqBase.__init(prob::AbstractSDDEProblem,# TODO DiffEqBasee.Abstract
 
     # create a history function
     history = build_history_function(prob, alg, reltol_internal,
-                                     rate_prototype, noise_rate_prototype, jump_prototype,
-                                     W, _seed, dense;
-                                     dt = dt, adaptive = adaptive,
-                                     internalnorm = internalnorm)
+        rate_prototype, noise_rate_prototype, jump_prototype,
+        W, _seed, dense;
+        dt = dt, adaptive = adaptive,
+        internalnorm = internalnorm)
     f_with_history, g_with_history = wrap_functions_and_history(f, g, history)
 
     sde_integrator = history.integrator
 
     cache = StochasticDiffEq.alg_cache(getalg(alg), prob, u, W.dW, W.dZ, p, rate_prototype,
-                                       noise_rate_prototype, jump_prototype, uEltypeNoUnits,
-                                       uBottomEltypeNoUnits, tTypeNoUnits, uprev,
-                                       f_with_history, t, dt, Val{isinplace(prob)})
+        noise_rate_prototype, jump_prototype, uEltypeNoUnits,
+        uBottomEltypeNoUnits, tTypeNoUnits, uprev,
+        f_with_history, t, dt, Val{isinplace(prob)})
 
     # id = StochasticDiffEq.LinearInterpolationData(timeseries,ts)
     id = StochasticDiffEq.LinearInterpolationData(sde_integrator.sol.u,
-                                                  sde_integrator.sol.t)
+        sde_integrator.sol.t)
 
     save_end_user = save_end
     save_end = save_end === nothing ?
@@ -382,51 +385,51 @@ function DiffEqBase.__init(prob::AbstractSDDEProblem,# TODO DiffEqBasee.Abstract
 
     if controller === nothing
         controller = StochasticDiffEq.default_controller(getalg(alg), cache,
-                                                         convert(QT, qoldinit), beta1,
-                                                         beta2)
+            convert(QT, qoldinit), beta1,
+            beta2)
     end
 
     opts = StochasticDiffEq.SDEOptions(maxiters, save_everystep,
-                                       adaptive, abstol_internal,
-                                       reltol_internal,
-                                       QT(gamma),
-                                       QT(qmax), QT(qmin),
-                                       QT(qsteady_max), QT(qsteady_min),
-                                       QT(qoldinit),
-                                       QT(failfactor),
-                                       tType(dtmax), tType(dtmin),
-                                       controller,
-                                       internalnorm, save_idxs,
-                                       tstops_internal, saveat_internal,
-                                       d_discontinuities_internal,
-                                       tstops, saveat, d_discontinuities,
-                                       userdata,
-                                       progress, progress_steps,
-                                       progress_name, progress_message,progress_id,
-                                       timeseries_errors, dense_errors,
-                                       convert.(uBottomEltypeNoUnits, delta),
-                                       dense, save_on, save_start, save_end, save_end_user,
-                                       save_noise,
-                                       callbacks_internal, isoutofdomain, unstable_check,
-                                       verbose, calck, force_dtmin,
-                                       advance_to_tstop, stop_at_next_tstop)
+        adaptive, abstol_internal,
+        reltol_internal,
+        QT(gamma),
+        QT(qmax), QT(qmin),
+        QT(qsteady_max), QT(qsteady_min),
+        QT(qoldinit),
+        QT(failfactor),
+        tType(dtmax), tType(dtmin),
+        controller,
+        internalnorm, save_idxs,
+        tstops_internal, saveat_internal,
+        d_discontinuities_internal,
+        tstops, saveat, d_discontinuities,
+        userdata,
+        progress, progress_steps,
+        progress_name, progress_message, progress_id,
+        timeseries_errors, dense_errors,
+        convert.(uBottomEltypeNoUnits, delta),
+        dense, save_on, save_start, save_end, save_end_user,
+        save_noise,
+        callbacks_internal, isoutofdomain, unstable_check,
+        verbose, calck, force_dtmin,
+        advance_to_tstop, stop_at_next_tstop)
 
     stats = DiffEqBase.Stats(0)
     if typeof(getalg(alg)) <: StochasticDiffEq.StochasticDiffEqCompositeAlgorithm
         # TODO: DISCONNECT!!!!
         sol = DiffEqBase.build_solution(prob, alg, sde_integrator.sol.t,
-                                        sde_integrator.sol.u, W = W,
-                                        stats = stats, saved_subsystem = saved_subsystem,
-                                        calculate_error = false, alg_choice = alg_choice,
-                                        interp = id, dense = dense, seed = _seed)
+            sde_integrator.sol.u, W = W,
+            stats = stats, saved_subsystem = saved_subsystem,
+            calculate_error = false, alg_choice = alg_choice,
+            interp = id, dense = dense, seed = _seed)
         # separate statistics of the integrator and the history
     else
         # TODO: DISCONNECT!!!!
         sol = DiffEqBase.build_solution(prob, alg, sde_integrator.sol.t,
-                                        sde_integrator.sol.u, W = W,
-                                        stats = stats, saved_subsystem = saved_subsystem,
-                                        calculate_error = false,
-                                        interp = id, dense = dense, seed = _seed)
+            sde_integrator.sol.u, W = W,
+            stats = stats, saved_subsystem = saved_subsystem,
+            calculate_error = false,
+            interp = id, dense = dense, seed = _seed)
         # separate statistics of the integrator and the history
     end
 
@@ -463,31 +466,31 @@ function DiffEqBase.__init(prob::AbstractSDDEProblem,# TODO DiffEqBasee.Abstract
     q = tTypeNoUnits(1)
 
     integrator = SDDEIntegrator{typeof(getalg(alg)), isinplace(prob), uType,
-                                uBottomEltype, tType, typeof(p), typeof(eigen_est),
-                                QT, uEltypeNoUnits, typeof(W), typeof(P),
-                                rateType, typeof(sol), typeof(cache), FType, GType,
-                                typeof(c),
-                                typeof(opts), typeof(noise), typeof(last_event_error),
-                                typeof(callback_cache), typeof(history),
-                                typeof(sde_integrator), typeof(initializealg)}(f_with_history,
-                                                        g_with_history, c, noise, uprev,
-                                                        tprev,
-                                                        order_discontinuity_t0,
-                                                        tracked_discontinuities,
-                                                        t, u, p, tType(dt), tType(dt),
-                                                        tType(dt), dtcache, tspan[2], tdir,
-                                                        just_hit_tstop, do_error_check,
-                                                        isout, event_last_time,
-                                                        vector_event_last_time,
-                                                        last_event_error, accept_step,
-                                                        last_stepfail, force_stepfail,
-                                                        dtchangeable, u_modified, saveiter,
-                                                        getalg(alg), sol,
-                                                        cache, callback_cache, tType(dt), W,
-                                                        P,
-                                                        opts, iter, success_iter, eigen_est,
-                                                        EEst, q, QT(qoldinit), q11, history,
-                                                        stats, sde_integrator, initializealg)
+        uBottomEltype, tType, typeof(p), typeof(eigen_est),
+        QT, uEltypeNoUnits, typeof(W), typeof(P),
+        rateType, typeof(sol), typeof(cache), FType, GType,
+        typeof(c),
+        typeof(opts), typeof(noise), typeof(last_event_error),
+        typeof(callback_cache), typeof(history),
+        typeof(sde_integrator), typeof(initializealg)}(f_with_history,
+        g_with_history, c, noise, uprev,
+        tprev,
+        order_discontinuity_t0,
+        tracked_discontinuities,
+        t, u, p, tType(dt), tType(dt),
+        tType(dt), dtcache, tspan[2], tdir,
+        just_hit_tstop, do_error_check,
+        isout, event_last_time,
+        vector_event_last_time,
+        last_event_error, accept_step,
+        last_stepfail, force_stepfail,
+        dtchangeable, u_modified, saveiter,
+        getalg(alg), sol,
+        cache, callback_cache, tType(dt), W,
+        P,
+        opts, iter, success_iter, eigen_est,
+        EEst, q, QT(qoldinit), q11, history,
+        stats, sde_integrator, initializealg)
 
     if initialize_integrator
         DiffEqBase.initialize_dae!(integrator)
@@ -518,7 +521,8 @@ function DiffEqBase.solve!(integrator::SDDEIntegrator)
             if DiffEqBase.check_error!(integrator) != ReturnCode.Success
                 return integrator.sol
             end
-            if !isempty(integrator.sol.prob.constant_lags) && integrator.dt > minimum(integrator.sol.prob.constant_lags) &&
+            if !isempty(integrator.sol.prob.constant_lags) &&
+               integrator.dt > minimum(integrator.sol.prob.constant_lags) &&
                !(integrator.alg <: StochasticDiffEq.EM)
                 error("dt > minimum(constant_lags). This is not allowed by the integrator. Please dt `dtmax` less than the minimum lag or use `EM`.")
             end
@@ -537,8 +541,8 @@ function DiffEqBase.solve!(integrator::SDDEIntegrator)
 
     if DiffEqBase.has_analytic(f)
         DiffEqBase.calculate_solution_errors!(integrator.sol;
-                                              timeseries_errors = integrator.opts.timeseries_errors,
-                                              dense_errors = integrator.opts.dense_errors)
+            timeseries_errors = integrator.opts.timeseries_errors,
+            dense_errors = integrator.opts.dense_errors)
     end
     if integrator.sol.retcode != :Default
         return integrator.sol
@@ -548,8 +552,8 @@ end
 
 # function StochasticDiffEq.tstop_saveat_disc_handling(tstops, saveat, d_discontinuities, tspan)
 function tstop_saveat_disc_handling(tstops, saveat, d_discontinuities, tspan,
-                                    order_discontinuity_t0, alg_maximum_order,
-                                    constant_lags, neutral)
+        order_discontinuity_t0, alg_maximum_order,
+        constant_lags, neutral)
     tType = eltype(tspan)
     t0, tf = tspan
     tdir = sign(tf - t0)
@@ -615,7 +619,7 @@ function tstop_saveat_disc_handling(tstops, saveat, d_discontinuities, tspan,
     d_discontinuities_internal = BinaryMinHeap{Discontinuity{tType, Rational{Int}}}()
     if add_propagated_constant_lags
         sizehint!(d_discontinuities_internal.valtree,
-                  length(d_discontinuities) + length(constant_lags))
+            length(d_discontinuities) + length(constant_lags))
     else
         sizehint!(d_discontinuities_internal.valtree, length(d_discontinuities))
     end
@@ -625,7 +629,7 @@ function tstop_saveat_disc_handling(tstops, saveat, d_discontinuities, tspan,
 
         if tdir_t0 < tdir_t < tdir_tf && d.order ≤ alg_maximum_order + 1
             push!(d_discontinuities_internal,
-                  Discontinuity{tType, Rational{Int}}(tdir_t, d.order))
+                Discontinuity{tType, Rational{Int}}(tdir_t, d.order))
         end
     end
 
@@ -633,7 +637,7 @@ function tstop_saveat_disc_handling(tstops, saveat, d_discontinuities, tspan,
         for lag in constant_lags
             if tdir * lag < maxlag
                 push!(d_discontinuities_internal,
-                      Discontinuity{tType, Rational{Int}}(tdir * (t0 + lag), next_order))
+                    Discontinuity{tType, Rational{Int}}(tdir * (t0 + lag), next_order))
             end
         end
     end

--- a/src/stepsize_controllers.jl
+++ b/src/stepsize_controllers.jl
@@ -4,8 +4,8 @@ function stepsize_controller!(integrator::SDDEIntegrator, controller::PIControll
     integrator.q = DiffEqBase.value(integrator.q11 /
                                     FastPower.fastpower(integrator.qold, controller.beta2))
     @fastmath integrator.q = DiffEqBase.value(max(inv(integrator.opts.qmax),
-                                                  min(inv(integrator.opts.qmin),
-                                                      integrator.q / integrator.opts.gamma)))
+        min(inv(integrator.opts.qmin),
+            integrator.q / integrator.opts.gamma)))
 end
 
 @inline function step_accept_controller!(integrator::SDDEIntegrator, alg)
@@ -19,5 +19,5 @@ end
 
 function step_reject_controller!(integrator::SDDEIntegrator, controller::PIController, alg)
     integrator.dtnew = integrator.dt / min(inv(integrator.opts.qmin),
-                           integrator.q11 / integrator.opts.gamma)
+        integrator.q11 / integrator.opts.gamma)
 end

--- a/test/analyticless_convergence_tests.jl
+++ b/test/analyticless_convergence_tests.jl
@@ -19,109 +19,112 @@ pmul = [1.0, -4.0, -2.0, 10.0, -1.3, -1.2, 1.1]
 padd = [1.0, -4.0, -2.0, 10.0, -0.0, -0.0, 0.1]
 
 prob = @test_nowarn SDDEProblem(hayes_modelf, hayes_modelg, [1.0], h, tspan, pmul;
-                                constant_lags = (pmul[1],));
+    constant_lags = (pmul[1],));
 @test_nowarn SDDEProblem(hayes_modelf, hayes_modelg, h, tspan, padd;
-                         constant_lags = (padd[1],));
+    constant_lags = (padd[1],));
 
 dts = (1 / 2) .^ (8:-1:4)
 test_dt = 1 / 2^9
 sim2 = analyticless_test_convergence(dts, prob, EM(), test_dt, trajectories = 300,
-                                     use_noise_grid = false)
+    use_noise_grid = false)
 @test abs(sim2.𝒪est[:final] - 0.5) < 0.3
 sim2 = analyticless_test_convergence(dts, prob, LambaEM(), test_dt, trajectories = 300,
-                                     use_noise_grid = false)
+    use_noise_grid = false)
 @test abs(sim2.𝒪est[:final] - 0.5) < 0.3
 sim2 = analyticless_test_convergence(dts, prob, EulerHeun(), test_dt, trajectories = 300,
-                                     use_noise_grid = false)
+    use_noise_grid = false)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3
 sim2 = analyticless_test_convergence(dts, prob, LambaEulerHeun(), test_dt,
-                                     trajectories = 300, use_noise_grid = false)
+    trajectories = 300, use_noise_grid = false)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3
 sim2 = analyticless_test_convergence(dts, prob, RKMil(), test_dt, trajectories = 300,
-                                     use_noise_grid = false)
+    use_noise_grid = false)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3
-sim2 = analyticless_test_convergence(dts, prob, RKMil(interpretation = SciMLBase.AlgorithmInterpretation.Stratonovich),
-                                     test_dt, trajectories = 300, use_noise_grid = false)
+sim2 = analyticless_test_convergence(
+    dts, prob, RKMil(interpretation = SciMLBase.AlgorithmInterpretation.Stratonovich),
+    test_dt, trajectories = 300, use_noise_grid = false)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3
 sim2 = analyticless_test_convergence(dts, prob, WangLi3SMil_A(), test_dt,
-                                     trajectories = 300, use_noise_grid = false)
+    trajectories = 300, use_noise_grid = false)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3
 sim2 = analyticless_test_convergence(dts, prob, WangLi3SMil_B(), test_dt,
-                                     trajectories = 300, use_noise_grid = false)
+    trajectories = 300, use_noise_grid = false)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3
 sim2 = analyticless_test_convergence(dts, prob, WangLi3SMil_C(), test_dt,
-                                     trajectories = 300, use_noise_grid = false)
+    trajectories = 300, use_noise_grid = false)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3
 sim2 = analyticless_test_convergence(dts, prob, WangLi3SMil_D(), test_dt,
-                                     trajectories = 300, use_noise_grid = false)
+    trajectories = 300, use_noise_grid = false)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3
 sim2 = analyticless_test_convergence(dts, prob, WangLi3SMil_E(), test_dt,
-                                     trajectories = 300, use_noise_grid = false)
+    trajectories = 300, use_noise_grid = false)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3
 sim2 = analyticless_test_convergence(dts, prob, WangLi3SMil_F(), test_dt,
-                                     trajectories = 300, use_noise_grid = false)
+    trajectories = 300, use_noise_grid = false)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3
 
 # Test SROCK methods
 println("SROCK methods")
 prob.p .= pmul;
 sim2 = analyticless_test_convergence(dts, prob, SROCK1(), test_dt, trajectories = 100,
-                                     use_noise_grid = false)
+    use_noise_grid = false)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3
-sim2 = analyticless_test_convergence(dts, prob, SROCK1(interpretation = SciMLBase.AlgorithmInterpretation.Stratonovich),
-                                     test_dt, trajectories = 300, use_noise_grid = false)
+sim2 = analyticless_test_convergence(
+    dts, prob, SROCK1(interpretation = SciMLBase.AlgorithmInterpretation.Stratonovich),
+    test_dt, trajectories = 300, use_noise_grid = false)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3
 sim2 = analyticless_test_convergence(dts, prob, SROCKEM(), test_dt, trajectories = 300,
-                                     use_noise_grid = false)
+    use_noise_grid = false)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3
 sim2 = analyticless_test_convergence(dts, prob, SROCKEM(strong_order_1 = false), test_dt,
-                                     trajectories = 300, use_noise_grid = false)
+    trajectories = 300, use_noise_grid = false)
 @test abs(sim2.𝒪est[:final] - 0.5) < 0.3
 sim2 = analyticless_test_convergence(dts, prob, SKSROCK(), test_dt, trajectories = 300,
-                                     use_noise_grid = false)
+    use_noise_grid = false)
 @test abs(sim2.𝒪est[:final] - 0.5) < 0.3
 sim2 = analyticless_test_convergence(dts, prob, SKSROCK(; post_processing = true), test_dt,
-                                     trajectories = 300, use_noise_grid = false)
+    trajectories = 300, use_noise_grid = false)
 @test abs(sim2.𝒪est[:final] - 0.5) < 0.3
 
 # Test Implicit methods
 println("implicit methods")
 sim2 = analyticless_test_convergence(dts, prob, ImplicitEM(), test_dt, trajectories = 300,
-                                     use_noise_grid = false)
+    use_noise_grid = false)
 @test abs(sim2.𝒪est[:final] - 0.5) < 0.3
 sim2 = analyticless_test_convergence(dts, prob,
-                                     ImplicitEM(symplectic = true, theta = 1 / 2), test_dt,
-                                     trajectories = 300, use_noise_grid = false)
+    ImplicitEM(symplectic = true, theta = 1 / 2), test_dt,
+    trajectories = 300, use_noise_grid = false)
 @test abs(sim2.𝒪est[:final] - 0.5) < 0.3
 sim2 = analyticless_test_convergence(dts, prob, ImplicitEulerHeun(), test_dt,
-                                     trajectories = 300, use_noise_grid = false)
+    trajectories = 300, use_noise_grid = false)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3
 sim2 = analyticless_test_convergence(dts, prob,
-                                     ImplicitEulerHeun(symplectic = true, theta = 1 / 2),
-                                     test_dt, trajectories = 300, use_noise_grid = false)
+    ImplicitEulerHeun(symplectic = true, theta = 1 / 2),
+    test_dt, trajectories = 300, use_noise_grid = false)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3
 sim2 = analyticless_test_convergence(dts, prob, ISSEM(), test_dt, trajectories = 1000,
-                                     use_noise_grid = false)
+    use_noise_grid = false)
 @test abs(sim2.𝒪est[:final] - 0.5) < 0.35
 sim2 = analyticless_test_convergence(dts, prob, ISSEM(symplectic = true, theta = 1 / 2),
-                                     test_dt, trajectories = 500, use_noise_grid = false)
+    test_dt, trajectories = 500, use_noise_grid = false)
 @test abs(sim2.𝒪est[:final] - 0.5) < 0.3
 sim2 = analyticless_test_convergence(dts, prob, ImplicitRKMil(), test_dt,
-                                     trajectories = 300, use_noise_grid = false)
+    trajectories = 300, use_noise_grid = false)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3
 sim2 = analyticless_test_convergence(dts, prob,
-                                     ImplicitRKMil(symplectic = true, theta = 1 / 2),
-                                     test_dt, trajectories = 300, use_noise_grid = false)
+    ImplicitRKMil(symplectic = true, theta = 1 / 2),
+    test_dt, trajectories = 300, use_noise_grid = false)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3
 sim2 = analyticless_test_convergence(dts, prob,
-                                     ImplicitRKMil(interpretation = SciMLBase.AlgorithmInterpretation.Stratonovich,
-                                                   symplectic = true, theta = 1 / 2),
-                                     test_dt, trajectories = 300, use_noise_grid = false)
+    ImplicitRKMil(interpretation = SciMLBase.AlgorithmInterpretation.Stratonovich,
+        symplectic = true, theta = 1 / 2),
+    test_dt, trajectories = 300, use_noise_grid = false)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3
-sim2 = analyticless_test_convergence(dts, prob, ISSEulerHeun(), test_dt, trajectories = 300,
-                                     use_noise_grid = false)
+sim2 = analyticless_test_convergence(
+    dts, prob, ISSEulerHeun(), test_dt, trajectories = 300,
+    use_noise_grid = false)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3
 sim2 = analyticless_test_convergence(dts, prob,
-                                     ISSEulerHeun(symplectic = true, theta = 1 / 2),
-                                     test_dt, trajectories = 300, use_noise_grid = false)
+    ISSEulerHeun(symplectic = true, theta = 1 / 2),
+    test_dt, trajectories = 300, use_noise_grid = false)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3

--- a/test/events.jl
+++ b/test/events.jl
@@ -9,7 +9,7 @@ using Test
 
     # event at `t = 3`
     cb = DiscreteCallback((u, t, integrator) -> t == 3,
-                          integrator -> (integrator.u = -integrator.u))
+        integrator -> (integrator.u = -integrator.u))
 
     sol = solve(prob, RKMil(), tstops = (3,), callback = cb)
     ts = findall(x -> x == 3, sol.t)

--- a/test/nondiagonal_sparse_noise.jl
+++ b/test/nondiagonal_sparse_noise.jl
@@ -63,5 +63,5 @@ p = [0.05, 10.0, 4.0]; # β,c,τ
 Random.seed!(1234);
 
 prob_sdde = SDDEProblem(sir_dde!, sir_delayed_noise!, u0, sir_history, tspan, p;
-                        noise_rate_prototype = A);
+    noise_rate_prototype = A);
 sol_sdde = solve(prob_sdde, LambaEM(), callback = cb);

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,14 @@
 using SafeTestsets
 
-@safetestset "SDDEProblem, solve" begin include("test_prob_sol.jl") end
-@safetestset "Analyticless Convergence Tests" begin include("analyticless_convergence_tests.jl") end
-@safetestset "Event handling" begin include("events.jl") end
-@safetestset "Non-Diagonal Sparse Noise" begin include("nondiagonal_sparse_noise.jl") end
+@safetestset "SDDEProblem, solve" begin
+    include("test_prob_sol.jl")
+end
+@safetestset "Analyticless Convergence Tests" begin
+    include("analyticless_convergence_tests.jl")
+end
+@safetestset "Event handling" begin
+    include("events.jl")
+end
+@safetestset "Non-Diagonal Sparse Noise" begin
+    include("nondiagonal_sparse_noise.jl")
+end

--- a/test/test_prob_sol.jl
+++ b/test/test_prob_sol.jl
@@ -19,9 +19,9 @@ pmul = [1.0, -4.0, -2.0, 10.0, -1.3, -1.2, 1.1]
 padd = [1.0, -4.0, -2.0, 10.0, -0.0, -0.0, 0.1]
 
 prob = @test_nowarn SDDEProblem(hayes_modelf, hayes_modelg, [1.0], h, tspan, pmul;
-                                constant_lags = (pmul[1],));
+    constant_lags = (pmul[1],));
 @test_nowarn SDDEProblem(hayes_modelf, hayes_modelg, h, tspan, padd;
-                         constant_lags = (padd[1],));
+    constant_lags = (padd[1],));
 
 sol = @test_nowarn solve(prob, EM(), dt = 0.01)
 @test sol.u[end] != zeros(1)
@@ -33,11 +33,13 @@ sol = @test_nowarn solve(prob, LambaEulerHeun(), dt = 0.01)
 @test sol.u[end] != zeros(1)
 sol = @test_nowarn solve(prob, RKMil(), dt = 0.01)
 @test sol.u[end] != zeros(1)
-sol = @test_nowarn solve(prob, RKMil(interpretation = SciMLBase.AlgorithmInterpretation.Stratonovich), dt = 0.01)
+sol = @test_nowarn solve(
+    prob, RKMil(interpretation = SciMLBase.AlgorithmInterpretation.Stratonovich), dt = 0.01)
 @test sol.u[end] != zeros(1)
 sol = @test_nowarn solve(prob, RKMilCommute(), dt = 0.01)
 @test sol.u[end] != zeros(1)
-sol = @test_nowarn solve(prob, RKMilCommute(interpretation = SciMLBase.AlgorithmInterpretation.Stratonovich), dt = 0.01)
+sol = @test_nowarn solve(
+    prob, RKMilCommute(interpretation = SciMLBase.AlgorithmInterpretation.Stratonovich), dt = 0.01)
 @test sol.u[end] != zeros(1)
 sol = @test_nowarn solve(prob, WangLi3SMil_A(), dt = 0.01)
 @test sol.u[end] != zeros(1)
@@ -84,7 +86,8 @@ println("SROCK methods")
 prob.p .= pmul;
 sol = @test_nowarn solve(prob, SROCK1(), dt = 0.01)
 @test sol.u[end] != zeros(1)
-sol = @test_nowarn solve(prob, SROCK1(interpretation = SciMLBase.AlgorithmInterpretation.Stratonovich), dt = 0.01)
+sol = @test_nowarn solve(
+    prob, SROCK1(interpretation = SciMLBase.AlgorithmInterpretation.Stratonovich), dt = 0.01)
 @test sol.u[end] != zeros(1)
 sol = @test_nowarn solve(prob, SROCKEM(), dt = 0.01)
 @test sol.u[end] != zeros(1)
@@ -112,15 +115,16 @@ sol = @test_nowarn solve(prob, ImplicitEM(symplectic = true, theta = 1 / 2), dt 
 sol = @test_nowarn solve(prob, ImplicitEulerHeun(), dt = 0.01)
 @test sol.u[end] != zeros(1)
 sol = @test_nowarn solve(prob, ImplicitEulerHeun(symplectic = true, theta = 1 / 2),
-                         dt = 0.01)
+    dt = 0.01)
 @test sol.u[end] != zeros(1)
 sol = @test_nowarn solve(prob, ImplicitRKMil(), dt = 0.01)
 @test sol.u[end] != zeros(1)
 sol = @test_nowarn solve(prob, ImplicitRKMil(symplectic = true, theta = 1 / 2), dt = 0.01)
 @test sol.u[end] != zeros(1)
 sol = @test_nowarn solve(prob,
-                         ImplicitRKMil(interpretation = SciMLBase.AlgorithmInterpretation.Stratonovich, symplectic = true,
-                                       theta = 1 / 2), dt = 0.01)
+    ImplicitRKMil(
+        interpretation = SciMLBase.AlgorithmInterpretation.Stratonovich, symplectic = true,
+        theta = 1 / 2), dt = 0.01)
 @test sol.u[end] != zeros(1)
 sol = @test_nowarn solve(prob, ISSEM(), dt = 0.01)
 @test sol.u[end] != zeros(1)


### PR DESCRIPTION
## Summary
- Fixed malformed `DiffEqBase.@..` macro syntax in `interface.jl:238` 
- Applied JuliaFormatter to standardize code formatting across the codebase
- Updated formatting in integrators, solve logic, and test files
- Resolves parsing error that prevented JuliaFormatter from processing the repository

## Changes
- **Bug Fix**: Corrected `DiffEqBase.@.. out = ...` to `@.. out = ...` in `get_du\!` function
- **Formatting**: Applied JuliaFormatter across 12 files with 390 insertions and 363 deletions
- **Files affected**: Core integrator logic, solve functions, utilities, and test files

## Test plan
- [x] Fixed parsing error - JuliaFormatter now runs successfully 
- [x] Applied comprehensive formatting improvements
- [ ] Existing tests should continue to pass
- [ ] No functional changes beyond the macro syntax fix

🤖 Generated with [Claude Code](https://claude.ai/code)