### PR TITLE
Switch from JuliaFormatter to Runic.jl for code formatting

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,1 +1,0 @@
-style = "sciml"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,13 +1,19 @@
-name: "Format Check"
+name: format-check
 
 on:
   push:
     branches:
       - 'master'
+      - 'main'
+      - 'release-'
     tags: '*'
   pull_request:
 
 jobs:
-  format-check:
-    name: "Format Check"
-    uses: "SciML/.github/.github/workflows/format-check.yml@v1"
+  runic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: fredrikekre/runic-action@v1
+        with:
+          version: '1'

--- a/src/StochasticDelayDiffEq.jl
+++ b/src/StochasticDelayDiffEq.jl
@@ -7,7 +7,7 @@ module StochasticDelayDiffEq
 using Reexport
 @reexport using StochasticDiffEq
 import StochasticDiffEq: stepsize_controller!, accept_step_controller,
-                         step_accept_controller!, step_reject_controller!, PIController
+    step_accept_controller!, step_reject_controller!, PIController
 # import StochasticDiffEq: calc_J, calc_J!, calc_tderivative!, calc_tderivative
 using LinearAlgebra, StaticArrays
 using UnPack, DataStructures
@@ -16,11 +16,11 @@ using RecursiveArrayTools
 import FastPower
 import SciMLBase
 using DiffEqBase: AbstractSDDEProblem, AbstractSDDEAlgorithm, AbstractRODESolution,
-                  AbstractRODEFunction, AbstractSDEIntegrator, AbstractSDDEIntegrator,
-                  DEIntegrator, DEAlgorithm, AbstractRODEAlgorithm, AbstractSDEAlgorithm, @..
+    AbstractRODEFunction, AbstractSDEIntegrator, AbstractSDDEIntegrator,
+    DEIntegrator, DEAlgorithm, AbstractRODEAlgorithm, AbstractSDEAlgorithm, @..
 
 import DelayDiffEq: constant_extrapolant!, constant_extrapolant,
-                    AbstractMethodOfStepsAlgorithm, iscomposite, MethodOfSteps
+    AbstractMethodOfStepsAlgorithm, iscomposite, MethodOfSteps
 using DiffEqNoiseProcess
 
 using DelayDiffEq: Discontinuity, HistoryFunction

--- a/src/functionwrapper.jl
+++ b/src/functionwrapper.jl
@@ -3,14 +3,15 @@ struct SDEDiffusionTermWrapper{iip, G, H}
     h::H
 end
 function SDEDiffusionTermWrapper(g::G, h::H) where {G, H}
-    SDEDiffusionTermWrapper{isinplace(g, 5), G, H}(g, h)
+    return SDEDiffusionTermWrapper{isinplace(g, 5), G, H}(g, h)
 end
 (g::SDEDiffusionTermWrapper{true})(du, u, p, t) = g.g(du, u, g.h, p, t)
 (g::SDEDiffusionTermWrapper{false})(u, p, t) = g.g(u, g.h, p, t)
 
 struct SDEFunctionWrapper{
-    iip, F, G, H, TMM, Ta, Tt, TJ, JVP, VJP, JP, SP, TW, TWt, TPJ, GG,
-    TCV, ID, S} <: DiffEqBase.AbstractRODEFunction{iip}
+        iip, F, G, H, TMM, Ta, Tt, TJ, JVP, VJP, JP, SP, TW, TWt, TPJ, GG,
+        TCV, ID, S,
+    } <: DiffEqBase.AbstractRODEFunction{iip}
     f::F
     g::G
     h::H
@@ -51,14 +52,18 @@ function wrap_functions_and_history(f::SDDEFunction, g, h)
         end
     end
 
-    SDEFunctionWrapper{isinplace(f), typeof(f.f), typeof(gwh), typeof(h),
-        typeof(f.mass_matrix),
-        typeof(f.analytic), typeof(f.tgrad), typeof(jac), typeof(f.jvp),
-        typeof(f.vjp), typeof(f.jac_prototype), typeof(f.sparsity),
-        typeof(f.Wfact), typeof(f.Wfact_t), typeof(f.paramjac),
-        typeof(f.ggprime), typeof(f.colorvec), typeof(f.initialization_data),
-        typeof(f.sys)}(f.f, gwh, h, f.mass_matrix, f.analytic, f.tgrad, jac,
-        f.jvp, f.vjp, f.jac_prototype, f.sparsity, f.Wfact, f.Wfact_t, f.paramjac,
-        f.ggprime, f.colorvec, f.initialization_data, f.sys),
-    gwh
+    return SDEFunctionWrapper{
+            isinplace(f), typeof(f.f), typeof(gwh), typeof(h),
+            typeof(f.mass_matrix),
+            typeof(f.analytic), typeof(f.tgrad), typeof(jac), typeof(f.jvp),
+            typeof(f.vjp), typeof(f.jac_prototype), typeof(f.sparsity),
+            typeof(f.Wfact), typeof(f.Wfact_t), typeof(f.paramjac),
+            typeof(f.ggprime), typeof(f.colorvec), typeof(f.initialization_data),
+            typeof(f.sys),
+        }(
+            f.f, gwh, h, f.mass_matrix, f.analytic, f.tgrad, jac,
+            f.jvp, f.vjp, f.jac_prototype, f.sparsity, f.Wfact, f.Wfact_t, f.paramjac,
+            f.ggprime, f.colorvec, f.initialization_data, f.sys
+        ),
+        gwh
 end

--- a/src/integrators/type.jl
+++ b/src/integrators/type.jl
@@ -1,5 +1,5 @@
 mutable struct HistorySDEIntegrator{algType, IIP, uType, tType, SolType, CacheType} <:
-               AbstractSDEIntegrator{algType, IIP, uType, tType}
+    AbstractSDEIntegrator{algType, IIP, uType, tType}
     sol::SolType
     u::uType
     t::tType
@@ -14,20 +14,24 @@ mutable struct HistorySDEIntegrator{algType, IIP, uType, tType, SolType, CacheTy
 end
 
 function (integrator::HistorySDEIntegrator)(t, deriv::Type = Val{0}; idxs = nothing)
-    StochasticDiffEq.current_interpolant(t, integrator, idxs, deriv)
+    return StochasticDiffEq.current_interpolant(t, integrator, idxs, deriv)
 end
 
-function (integrator::HistorySDEIntegrator)(val::AbstractArray,
+function (integrator::HistorySDEIntegrator)(
+        val::AbstractArray,
         t::Union{Number, AbstractArray},
-        deriv::Type = Val{0}; idxs = nothing)
-    StochasticDiffEq.current_interpolant!(val, t, integrator, idxs, deriv)
+        deriv::Type = Val{0}; idxs = nothing
+    )
+    return StochasticDiffEq.current_interpolant!(val, t, integrator, idxs, deriv)
 end
 
-mutable struct SDDEIntegrator{algType, IIP, uType, uEltype, tType, P, eigenType,
-    tTypeNoUnits, uEltypeNoUnits, randType, randType2, rateType,
-    solType, cacheType, F, G, F6, OType, noiseType,
-    EventErrorType, CallbackCacheType, H, IType, IA} <:
-               AbstractSDDEIntegrator{algType, IIP, uType, tType}
+mutable struct SDDEIntegrator{
+        algType, IIP, uType, uEltype, tType, P, eigenType,
+        tTypeNoUnits, uEltypeNoUnits, randType, randType2, rateType,
+        solType, cacheType, F, G, F6, OType, noiseType,
+        EventErrorType, CallbackCacheType, H, IType, IA,
+    } <:
+    AbstractSDDEIntegrator{algType, IIP, uType, tType}
     f::F
     g::G
     c::F6
@@ -85,10 +89,12 @@ mutable struct SDDEIntegrator{algType, IIP, uType, uEltype, tType, P, eigenType,
 end
 
 function (integrator::SDDEIntegrator)(t, deriv::Type = Val{0}; idxs = nothing)
-    StochasticDiffEq.current_interpolant(t, integrator, idxs, deriv)
+    return StochasticDiffEq.current_interpolant(t, integrator, idxs, deriv)
 end
 
-function (integrator::SDDEIntegrator)(val::AbstractArray, t::Union{Number, AbstractArray},
-        deriv::Type = Val{0}; idxs = nothing)
-    StochasticDiffEq.current_interpolant!(val, t, integrator, idxs, deriv)
+function (integrator::SDDEIntegrator)(
+        val::AbstractArray, t::Union{Number, AbstractArray},
+        deriv::Type = Val{0}; idxs = nothing
+    )
+    return StochasticDiffEq.current_interpolant!(val, t, integrator, idxs, deriv)
 end

--- a/src/integrators/utils.jl
+++ b/src/integrators/utils.jl
@@ -1,6 +1,6 @@
 @inline function handle_tstop!(integrator)
     tstops = integrator.opts.tstops
-    if !isempty(tstops)
+    return if !isempty(tstops)
         tdir_t = integrator.tdir * integrator.t
         tdir_ts_top = first(tstops)
         if tdir_t == tdir_ts_top
@@ -8,8 +8,10 @@
             integrator.just_hit_tstop = true
         elseif tdir_t > tdir_ts_top
             if !integrator.dtchangeable
-                change_t_via_interpolation!(integrator, integrator.tdir * pop!(tstops),
-                    Val{true})
+                change_t_via_interpolation!(
+                    integrator, integrator.tdir * pop!(tstops),
+                    Val{true}
+                )
                 integrator.just_hit_tstop = true
             else
                 error("Something went wrong. Integrator stepped past tstops but the algorithm was dtchangeable. Please report this error.")
@@ -43,7 +45,7 @@ function handle_discontinuities!(integrator::SDDEIntegrator)
     d = pop!(integrator.opts.d_discontinuities)
     order = d.order
     while !isempty(integrator.opts.d_discontinuities) &&
-        first(integrator.opts.d_discontinuities) == integrator.tdir * integrator.t
+            first(integrator.opts.d_discontinuities) == integrator.tdir * integrator.t
         d2 = pop!(integrator.opts.d_discontinuities)
         order = min(order, d2.order)
     end
@@ -55,23 +57,25 @@ function handle_discontinuities!(integrator::SDDEIntegrator)
         maxΔt = 10eps(integrator.t)
 
         while !isempty(integrator.opts.d_discontinuities) &&
-            abs(first(integrator.opts.d_discontinuities).t -
-                integrator.tdir * integrator.t) <
-            maxΔt
+                abs(
+                first(integrator.opts.d_discontinuities).t -
+                    integrator.tdir * integrator.t
+            ) <
+                maxΔt
             d2 = pop!(integrator.opts.d_discontinuities)
             order = min(order, d2.order)
         end
 
         # also remove all corresponding time stops
         while !isempty(integrator.opts.tstops) &&
-            abs(first(integrator.opts.tstops) - integrator.tdir * integrator.t) < maxΔt
+                abs(first(integrator.opts.tstops) - integrator.tdir * integrator.t) < maxΔt
             pop!(integrator.opts.tstops)
         end
     end
 
     # add discontinuities of next order to integrator
     add_next_discontinuities!(integrator, order)
-    nothing
+    return nothing
 end
 
 """
@@ -110,5 +114,5 @@ function add_next_discontinuities!(integrator, _order, t = integrator.t)
 
     # track propagated discontinuities with callback
     push!(integrator.tracked_discontinuities, Discontinuity(integrator.tdir * t, order))
-    nothing
+    return nothing
 end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -1,12 +1,15 @@
-function DiffEqBase.__solve(prob::AbstractSDDEProblem, # TODO: DiffEqBase.AbstractSDDEProblem
+function DiffEqBase.__solve(
+        prob::AbstractSDDEProblem, # TODO: DiffEqBase.AbstractSDDEProblem
         alg::AbstractSDEAlgorithm, args...; # TODO: Method of steps???
-        kwargs...)
+        kwargs...
+    )
     integrator = DiffEqBase.__init(prob, alg, args...; kwargs...)
     DiffEqBase.solve!(integrator)
-    integrator.sol
+    return integrator.sol
 end
 
-function DiffEqBase.__init(prob::AbstractSDDEProblem,# TODO DiffEqBasee.AbstractSDDEProblem
+function DiffEqBase.__init(
+        prob::AbstractSDDEProblem, # TODO DiffEqBasee.AbstractSDDEProblem
         alg::Union{AbstractRODEAlgorithm, AbstractSDEAlgorithm},
         timeseries_init = typeof(prob.u0)[],
         ts_init = eltype(prob.tspan)[],
@@ -14,17 +17,21 @@ function DiffEqBase.__init(prob::AbstractSDDEProblem,# TODO DiffEqBasee.Abstract
         recompile::Type{Val{recompile_flag}} = Val{true};
         saveat = eltype(prob.tspan)[],
         tstops = eltype(prob.tspan)[],
-        d_discontinuities = Discontinuity{eltype(prob.tspan),
-            Rational{Int}}[],
+        d_discontinuities = Discontinuity{
+            eltype(prob.tspan),
+            Rational{Int},
+        }[],
         save_idxs = nothing,
         save_everystep = isempty(saveat),
-        save_noise = save_everystep && (prob.f isa Tuple ?
-                      DiffEqBase.has_analytic(prob.f[1]) :
-                      DiffEqBase.has_analytic(prob.f)),
+        save_noise = save_everystep && (
+            prob.f isa Tuple ?
+                DiffEqBase.has_analytic(prob.f[1]) :
+                DiffEqBase.has_analytic(prob.f)
+        ),
         save_on = true,
         save_start = save_everystep || isempty(saveat) ||
-                     saveat isa Number ? true :
-                     prob.tspan[1] in saveat,
+            saveat isa Number ? true :
+            prob.tspan[1] in saveat,
         save_end = nothing,
         callback = nothing,
         dense = save_everystep && isempty(saveat),
@@ -47,9 +54,9 @@ function DiffEqBase.__init(prob::AbstractSDDEProblem,# TODO DiffEqBasee.Abstract
         maxiters = adaptive ? 1000000 : typemax(Int),
         dtmax = eltype(prob.tspan)((prob.tspan[end] - prob.tspan[1])),
         dtmin = typeof(one(eltype(prob.tspan))) <: AbstractFloat ?
-                eps(eltype(prob.tspan)) :
-                typeof(one(eltype(prob.tspan))) <: Integer ? 0 :
-                eltype(prob.tspan)(1 // 10^(10)),
+            eps(eltype(prob.tspan)) :
+            typeof(one(eltype(prob.tspan))) <: Integer ? 0 :
+            eltype(prob.tspan)(1 // 10^(10)),
         internalnorm = DiffEqBase.ODE_DEFAULT_NORM,
         isoutofdomain = DiffEqBase.ODE_DEFAULT_ISOUTOFDOMAIN,
         unstable_check = DiffEqBase.ODE_DEFAULT_UNSTABLE_CHECK,
@@ -67,7 +74,8 @@ function DiffEqBase.__init(prob::AbstractSDDEProblem,# TODO DiffEqBasee.Abstract
         discontinuity_interp_points::Int = 10,
         discontinuity_abstol = eltype(prob.tspan)(1 // Int64(10)^12),
         discontinuity_reltol = 0,
-        initializealg = StochasticDiffEq.OrdinaryDiffEqCore.DefaultInit(), kwargs...) where {recompile_flag}
+        initializealg = StochasticDiffEq.OrdinaryDiffEqCore.DefaultInit(), kwargs...
+    ) where {recompile_flag}
 
     # alg = getalg(alg0);
     if prob.f isa Tuple
@@ -101,7 +109,7 @@ function DiffEqBase.__init(prob::AbstractSDDEProblem,# TODO DiffEqBasee.Abstract
         @warn "minimal_solution is ignored"
     end
 
-    progress && @logmsg(LogLevel(-1), progress_name, _id=progress_id, progress=0)
+    progress && @logmsg(LogLevel(-1), progress_name, _id = progress_id, progress = 0)
 
     tType = eltype(prob.tspan)
     noise = prob.noise
@@ -139,8 +147,12 @@ function DiffEqBase.__init(prob::AbstractSDDEProblem,# TODO DiffEqBasee.Abstract
 
     if abstol === nothing
         if uBottomEltypeNoUnits == uBottomEltype
-            abstol_internal = real(convert(uBottomEltype,
-                oneunit(uBottomEltype) * 1 // 10^2))
+            abstol_internal = real(
+                convert(
+                    uBottomEltype,
+                    oneunit(uBottomEltype) * 1 // 10^2
+                )
+            )
         else
             abstol_internal = real.(oneunit.(u) .* 1 // 10^2)
         end
@@ -150,8 +162,12 @@ function DiffEqBase.__init(prob::AbstractSDDEProblem,# TODO DiffEqBasee.Abstract
 
     if reltol === nothing
         if uBottomEltypeNoUnits == uBottomEltype
-            reltol_internal = real(convert(uBottomEltype,
-                oneunit(uBottomEltype) * 1 // 10^2))
+            reltol_internal = real(
+                convert(
+                    uBottomEltype,
+                    oneunit(uBottomEltype) * 1 // 10^2
+                )
+            )
         else
             reltol_internal = real.(oneunit.(u) .* 1 // 10^2)
         end
@@ -160,13 +176,17 @@ function DiffEqBase.__init(prob::AbstractSDDEProblem,# TODO DiffEqBasee.Abstract
     end
 
     if isinplace(prob) && u isa AbstractArray && eltype(u) <: Number &&
-       uBottomEltypeNoUnits == uBottomEltype # Could this be more efficient for other arrays?
+            uBottomEltypeNoUnits == uBottomEltype # Could this be more efficient for other arrays?
         if !(u isa ArrayPartition)
             rate_prototype = recursivecopy(u)
         else
-            rate_prototype = similar(u,
-                typeof.(oneunit.(recursive_bottom_eltype.(u.x)) ./
-                        oneunit(tType))...)
+            rate_prototype = similar(
+                u,
+                typeof.(
+                    oneunit.(recursive_bottom_eltype.(u.x)) ./
+                        oneunit(tType)
+                )...
+            )
         end
     else
         if uBottomEltypeNoUnits == uBottomEltype
@@ -227,27 +247,33 @@ function DiffEqBase.__init(prob::AbstractSDDEProblem,# TODO DiffEqBasee.Abstract
     # retrieve time stops, time points at which solutions is saved, and discontinuities
     maximum_order = StochasticDiffEq.alg_order(getalg(alg))
     tstops_internal, saveat_internal,
-    d_discontinuities_internal = tstop_saveat_disc_handling(tstops,
+        d_discontinuities_internal = tstop_saveat_disc_handling(
+        tstops,
         saveat,
         d_discontinuities,
         tspan,
         order_discontinuity_t0,
         maximum_order,
         constant_lags,
-        neutral)
+        neutral
+    )
 
     tracked_discontinuities = Discontinuity{tType, Rational{Int}}[]
     if order_discontinuity_t0 ≤ maximum_order
-        push!(tracked_discontinuities,
-            Discontinuity(tdir * t, Rational{Int}(order_discontinuity_t0)))
+        push!(
+            tracked_discontinuities,
+            Discontinuity(tdir * t, Rational{Int}(order_discontinuity_t0))
+        )
     end
 
     callbacks_internal = CallbackSet(callback)
 
     max_len_cb = DiffEqBase.max_vector_callback_length(callbacks_internal)
     if max_len_cb isa DiffEqBase.VectorContinuousCallback
-        callback_cache = DiffEqBase.CallbackCache(max_len_cb.len, uBottomEltype,
-            uBottomEltype)
+        callback_cache = DiffEqBase.CallbackCache(
+            max_len_cb.len, uBottomEltype,
+            uBottomEltype
+        )
     else
         callback_cache = nothing
     end
@@ -277,30 +303,38 @@ function DiffEqBase.__init(prob::AbstractSDDEProblem,# TODO DiffEqBasee.Abstract
 
     if prob.noise === nothing
         rswm = StochasticDiffEq.isadaptive(getalg(alg)) ? RSWM(adaptivealg = :RSwM3) :
-               RSWM(adaptivealg = :RSwM1)
+            RSWM(adaptivealg = :RSwM1)
         if isinplace(prob)
             if StochasticDiffEq.alg_needs_extra_process(getalg(alg))
-                W = WienerProcess!(t, rand_prototype, rand_prototype,
+                W = WienerProcess!(
+                    t, rand_prototype, rand_prototype,
                     save_everystep = save_noise,
                     rswm = rswm,
-                    rng = Xorshifts.Xoroshiro128Plus(_seed))
+                    rng = Xorshifts.Xoroshiro128Plus(_seed)
+                )
             else
-                W = WienerProcess!(t, rand_prototype,
+                W = WienerProcess!(
+                    t, rand_prototype,
                     save_everystep = save_noise,
                     rswm = rswm,
-                    rng = Xorshifts.Xoroshiro128Plus(_seed))
+                    rng = Xorshifts.Xoroshiro128Plus(_seed)
+                )
             end
         else
             if StochasticDiffEq.alg_needs_extra_process(getalg(alg))
-                W = WienerProcess(t, rand_prototype, rand_prototype,
+                W = WienerProcess(
+                    t, rand_prototype, rand_prototype,
                     save_everystep = save_noise,
                     rswm = rswm,
-                    rng = Xorshifts.Xoroshiro128Plus(_seed))
+                    rng = Xorshifts.Xoroshiro128Plus(_seed)
+                )
             else
-                W = WienerProcess(t, rand_prototype,
+                W = WienerProcess(
+                    t, rand_prototype,
                     save_everystep = save_noise,
                     rswm = rswm,
-                    rng = Xorshifts.Xoroshiro128Plus(_seed))
+                    rng = Xorshifts.Xoroshiro128Plus(_seed)
+                )
             end
         end
     else
@@ -319,16 +353,18 @@ function DiffEqBase.__init(prob::AbstractSDDEProblem,# TODO DiffEqBasee.Abstract
     end
 
     save_idxs,
-    saved_subsystem = SciMLBase.get_save_idxs_and_saved_subsystem(prob, save_idxs)
+        saved_subsystem = SciMLBase.get_save_idxs_and_saved_subsystem(prob, save_idxs)
     ts, timeseries,
-    saveiter = solution_arrays(u, tspan, rate_prototype,
+        saveiter = solution_arrays(
+        u, tspan, rate_prototype,
         timeseries_init = timeseries_init,
         ts_init = ts_init, save_idxs = save_idxs,
-        save_start = save_start)
+        save_start = save_start
+    )
 
     if !adaptive && save_everystep && tspan[2] - tspan[1] != Inf
         iszero(dt) ? steps = length(tstops) :
-        steps = ceil(Int, internalnorm((tspan[2] - tspan[1]) / dt, tspan[1]))
+            steps = ceil(Int, internalnorm((tspan[2] - tspan[1]) / dt, tspan[1]))
         sizehint!(timeseries, steps + 1)
         sizehint!(ts, steps + 1)
     elseif save_everystep
@@ -344,33 +380,39 @@ function DiffEqBase.__init(prob::AbstractSDDEProblem,# TODO DiffEqBasee.Abstract
 
     alg_choice = Int[]
     if save_start &&
-       typeof(getalg(alg)) <: StochasticDiffEq.StochasticDiffEqCompositeAlgorithm
+            typeof(getalg(alg)) <: StochasticDiffEq.StochasticDiffEqCompositeAlgorithm
         copyat_or_push!(alg_choice, 1, 1)
     end
 
     # create a history function
-    history = build_history_function(prob, alg, reltol_internal,
+    history = build_history_function(
+        prob, alg, reltol_internal,
         rate_prototype, noise_rate_prototype, jump_prototype,
         W, _seed, dense;
         dt = dt, adaptive = adaptive,
-        internalnorm = internalnorm)
+        internalnorm = internalnorm
+    )
     f_with_history, g_with_history = wrap_functions_and_history(f, g, history)
 
     sde_integrator = history.integrator
 
-    cache = StochasticDiffEq.alg_cache(getalg(alg), prob, u, W.dW, W.dZ, p, rate_prototype,
+    cache = StochasticDiffEq.alg_cache(
+        getalg(alg), prob, u, W.dW, W.dZ, p, rate_prototype,
         noise_rate_prototype, jump_prototype, uEltypeNoUnits,
         uBottomEltypeNoUnits, tTypeNoUnits, uprev,
-        f_with_history, t, dt, Val{isinplace(prob)})
+        f_with_history, t, dt, Val{isinplace(prob)}
+    )
 
     # id = StochasticDiffEq.LinearInterpolationData(timeseries,ts)
-    id = StochasticDiffEq.LinearInterpolationData(sde_integrator.sol.u,
-        sde_integrator.sol.t)
+    id = StochasticDiffEq.LinearInterpolationData(
+        sde_integrator.sol.u,
+        sde_integrator.sol.t
+    )
 
     save_end_user = save_end
     save_end = save_end === nothing ?
-               save_everystep || isempty(saveat) || saveat isa Number ||
-               prob.tspan[2] in saveat : save_end
+        save_everystep || isempty(saveat) || saveat isa Number ||
+        prob.tspan[2] in saveat : save_end
 
     # Setting up the step size controller
     if (beta1 !== nothing || beta2 !== nothing) && controller !== nothing
@@ -384,12 +426,15 @@ function DiffEqBase.__init(prob::AbstractSDDEProblem,# TODO DiffEqBasee.Abstract
     end
 
     if controller === nothing
-        controller = StochasticDiffEq.default_controller(getalg(alg), cache,
+        controller = StochasticDiffEq.default_controller(
+            getalg(alg), cache,
             convert(QT, qoldinit), beta1,
-            beta2)
+            beta2
+        )
     end
 
-    opts = StochasticDiffEq.SDEOptions(maxiters, save_everystep,
+    opts = StochasticDiffEq.SDEOptions(
+        maxiters, save_everystep,
         adaptive, abstol_internal,
         reltol_internal,
         QT(gamma),
@@ -412,24 +457,29 @@ function DiffEqBase.__init(prob::AbstractSDDEProblem,# TODO DiffEqBasee.Abstract
         save_noise,
         callbacks_internal, isoutofdomain, unstable_check,
         verbose, calck, force_dtmin,
-        advance_to_tstop, stop_at_next_tstop)
+        advance_to_tstop, stop_at_next_tstop
+    )
 
     stats = DiffEqBase.Stats(0)
     if typeof(getalg(alg)) <: StochasticDiffEq.StochasticDiffEqCompositeAlgorithm
         # TODO: DISCONNECT!!!!
-        sol = DiffEqBase.build_solution(prob, alg, sde_integrator.sol.t,
+        sol = DiffEqBase.build_solution(
+            prob, alg, sde_integrator.sol.t,
             sde_integrator.sol.u, W = W,
             stats = stats, saved_subsystem = saved_subsystem,
             calculate_error = false, alg_choice = alg_choice,
-            interp = id, dense = dense, seed = _seed)
+            interp = id, dense = dense, seed = _seed
+        )
         # separate statistics of the integrator and the history
     else
         # TODO: DISCONNECT!!!!
-        sol = DiffEqBase.build_solution(prob, alg, sde_integrator.sol.t,
+        sol = DiffEqBase.build_solution(
+            prob, alg, sde_integrator.sol.t,
             sde_integrator.sol.u, W = W,
             stats = stats, saved_subsystem = saved_subsystem,
             calculate_error = false,
-            interp = id, dense = dense, seed = _seed)
+            interp = id, dense = dense, seed = _seed
+        )
         # separate statistics of the integrator and the history
     end
 
@@ -465,14 +515,17 @@ function DiffEqBase.__init(prob::AbstractSDDEProblem,# TODO DiffEqBasee.Abstract
     success_iter = 0
     q = tTypeNoUnits(1)
 
-    integrator = SDDEIntegrator{typeof(getalg(alg)), isinplace(prob), uType,
+    integrator = SDDEIntegrator{
+        typeof(getalg(alg)), isinplace(prob), uType,
         uBottomEltype, tType, typeof(p), typeof(eigen_est),
         QT, uEltypeNoUnits, typeof(W), typeof(P),
         rateType, typeof(sol), typeof(cache), FType, GType,
         typeof(c),
         typeof(opts), typeof(noise), typeof(last_event_error),
         typeof(callback_cache), typeof(history),
-        typeof(sde_integrator), typeof(initializealg)}(f_with_history,
+        typeof(sde_integrator), typeof(initializealg),
+    }(
+        f_with_history,
         g_with_history, c, noise, uprev,
         tprev,
         order_discontinuity_t0,
@@ -490,7 +543,8 @@ function DiffEqBase.__init(prob::AbstractSDDEProblem,# TODO DiffEqBasee.Abstract
         P,
         opts, iter, success_iter, eigen_est,
         EEst, q, QT(qoldinit), q11, history,
-        stats, sde_integrator, initializealg)
+        stats, sde_integrator, initializealg
+    )
 
     if initialize_integrator
         DiffEqBase.initialize_dae!(integrator)
@@ -514,7 +568,7 @@ function DiffEqBase.__init(prob::AbstractSDDEProblem,# TODO DiffEqBasee.Abstract
     integrator.W.dt = integrator.dt
     DiffEqNoiseProcess.setup_next_step!(integrator)
 
-    integrator
+    return integrator
 end
 
 function DiffEqBase.solve!(integrator::SDDEIntegrator)
@@ -525,8 +579,8 @@ function DiffEqBase.solve!(integrator::SDDEIntegrator)
                 return integrator.sol
             end
             if !isempty(integrator.sol.prob.constant_lags) &&
-               integrator.dt > minimum(integrator.sol.prob.constant_lags) &&
-               !(integrator.alg <: StochasticDiffEq.EM)
+                    integrator.dt > minimum(integrator.sol.prob.constant_lags) &&
+                    !(integrator.alg <: StochasticDiffEq.EM)
                 error("dt > minimum(constant_lags). This is not allowed by the integrator. Please dt `dtmax` less than the minimum lag or use `EM`.")
             end
             StochasticDiffEq.perform_step!(integrator, integrator.cache)
@@ -543,20 +597,24 @@ function DiffEqBase.solve!(integrator::SDDEIntegrator)
         integrator.sol.prob.f
 
     if DiffEqBase.has_analytic(f)
-        DiffEqBase.calculate_solution_errors!(integrator.sol;
+        DiffEqBase.calculate_solution_errors!(
+            integrator.sol;
             timeseries_errors = integrator.opts.timeseries_errors,
-            dense_errors = integrator.opts.dense_errors)
+            dense_errors = integrator.opts.dense_errors
+        )
     end
     if integrator.sol.retcode != :Default
         return integrator.sol
     end
-    integrator.sol = DiffEqBase.solution_new_retcode(integrator.sol, ReturnCode.Success)
+    return integrator.sol = DiffEqBase.solution_new_retcode(integrator.sol, ReturnCode.Success)
 end
 
 # function StochasticDiffEq.tstop_saveat_disc_handling(tstops, saveat, d_discontinuities, tspan)
-function tstop_saveat_disc_handling(tstops, saveat, d_discontinuities, tspan,
+function tstop_saveat_disc_handling(
+        tstops, saveat, d_discontinuities, tspan,
         order_discontinuity_t0, alg_maximum_order,
-        constant_lags, neutral)
+        constant_lags, neutral
+    )
     tType = eltype(tspan)
     t0, tf = tspan
     tdir = sign(tf - t0)
@@ -565,7 +623,7 @@ function tstop_saveat_disc_handling(tstops, saveat, d_discontinuities, tspan,
 
     # add discontinuities propagated from initial discontinuity
     add_propagated_constant_lags = order_discontinuity_t0 ≤ alg_maximum_order &&
-                                   constant_lags !== nothing && !isempty(constant_lags)
+        constant_lags !== nothing && !isempty(constant_lags)
 
     if add_propagated_constant_lags
         maxlag = tdir_tf - tdir_t0
@@ -621,8 +679,10 @@ function tstop_saveat_disc_handling(tstops, saveat, d_discontinuities, tspan,
     # discontinuities
     d_discontinuities_internal = BinaryMinHeap{Discontinuity{tType, Rational{Int}}}()
     if add_propagated_constant_lags
-        sizehint!(d_discontinuities_internal.valtree,
-            length(d_discontinuities) + length(constant_lags))
+        sizehint!(
+            d_discontinuities_internal.valtree,
+            length(d_discontinuities) + length(constant_lags)
+        )
     else
         sizehint!(d_discontinuities_internal.valtree, length(d_discontinuities))
     end
@@ -631,19 +691,23 @@ function tstop_saveat_disc_handling(tstops, saveat, d_discontinuities, tspan,
         tdir_t = tdir * d.t
 
         if tdir_t0 < tdir_t < tdir_tf && d.order ≤ alg_maximum_order + 1
-            push!(d_discontinuities_internal,
-                Discontinuity{tType, Rational{Int}}(tdir_t, d.order))
+            push!(
+                d_discontinuities_internal,
+                Discontinuity{tType, Rational{Int}}(tdir_t, d.order)
+            )
         end
     end
 
     if add_propagated_constant_lags
         for lag in constant_lags
             if tdir * lag < maxlag
-                push!(d_discontinuities_internal,
-                    Discontinuity{tType, Rational{Int}}(tdir * (t0 + lag), next_order))
+                push!(
+                    d_discontinuities_internal,
+                    Discontinuity{tType, Rational{Int}}(tdir * (t0 + lag), next_order)
+                )
             end
         end
     end
 
-    tstops_internal, saveat_internal, d_discontinuities_internal
+    return tstops_internal, saveat_internal, d_discontinuities_internal
 end

--- a/src/stepsize_controllers.jl
+++ b/src/stepsize_controllers.jl
@@ -1,23 +1,32 @@
-
 function stepsize_controller!(integrator::SDDEIntegrator, controller::PIController, alg)
     integrator.q11 = DiffEqBase.value(FastPower.fastpower(integrator.EEst, controller.beta1))
-    integrator.q = DiffEqBase.value(integrator.q11 /
-                                    FastPower.fastpower(integrator.qold, controller.beta2))
-    @fastmath integrator.q = DiffEqBase.value(max(inv(integrator.opts.qmax),
-        min(inv(integrator.opts.qmin),
-            integrator.q / integrator.opts.gamma)))
+    integrator.q = DiffEqBase.value(
+        integrator.q11 /
+            FastPower.fastpower(integrator.qold, controller.beta2)
+    )
+    return @fastmath integrator.q = DiffEqBase.value(
+        max(
+            inv(integrator.opts.qmax),
+            min(
+                inv(integrator.opts.qmin),
+                integrator.q / integrator.opts.gamma
+            )
+        )
+    )
 end
 
 @inline function step_accept_controller!(integrator::SDDEIntegrator, alg)
-    step_accept_controller!(integrator, integrator.opts.controller, alg)
+    return step_accept_controller!(integrator, integrator.opts.controller, alg)
 end
 
 function step_accept_controller!(integrator::SDDEIntegrator, controller::PIController, alg)
-    integrator.dtnew = DiffEqBase.value(integrator.dt / integrator.q) *
-                       oneunit(integrator.dt)
+    return integrator.dtnew = DiffEqBase.value(integrator.dt / integrator.q) *
+        oneunit(integrator.dt)
 end
 
 function step_reject_controller!(integrator::SDDEIntegrator, controller::PIController, alg)
-    integrator.dtnew = integrator.dt / min(inv(integrator.opts.qmin),
-        integrator.q11 / integrator.opts.gamma)
+    return integrator.dtnew = integrator.dt / min(
+        inv(integrator.opts.qmin),
+        integrator.q11 / integrator.opts.gamma
+    )
 end

--- a/test/analyticless_convergence_tests.jl
+++ b/test/analyticless_convergence_tests.jl
@@ -5,11 +5,11 @@ using Test
 begin
     function hayes_modelf(du, u, h, p, t)
         τ, a, b, c, α, β, γ = p
-        du .= a .* u .+ b .* h(p, t - τ) .+ c
+        return du .= a .* u .+ b .* h(p, t - τ) .+ c
     end
     function hayes_modelg(du, u, h, p, t)
         τ, a, b, c, α, β, γ = p
-        du .= α .* u .+ γ
+        return du .= α .* u .+ γ
     end
     h(p, t) = (ones(1) .+ t)
     tspan = (0.0, 10.0)
@@ -18,113 +18,174 @@ end
 pmul = [1.0, -4.0, -2.0, 10.0, -1.3, -1.2, 1.1]
 padd = [1.0, -4.0, -2.0, 10.0, -0.0, -0.0, 0.1]
 
-prob = @test_nowarn SDDEProblem(hayes_modelf, hayes_modelg, [1.0], h, tspan, pmul;
-    constant_lags = (pmul[1],));
-@test_nowarn SDDEProblem(hayes_modelf, hayes_modelg, h, tspan, padd;
-    constant_lags = (padd[1],));
+prob = @test_nowarn SDDEProblem(
+    hayes_modelf, hayes_modelg, [1.0], h, tspan, pmul;
+    constant_lags = (pmul[1],)
+);
+@test_nowarn SDDEProblem(
+    hayes_modelf, hayes_modelg, h, tspan, padd;
+    constant_lags = (padd[1],)
+);
 
 dts = (1 / 2) .^ (8:-1:4)
 test_dt = 1 / 2^9
-sim2 = analyticless_test_convergence(dts, prob, EM(), test_dt, trajectories = 300,
-    use_noise_grid = false)
+sim2 = analyticless_test_convergence(
+    dts, prob, EM(), test_dt, trajectories = 300,
+    use_noise_grid = false
+)
 @test abs(sim2.𝒪est[:final] - 0.5) < 0.3
-sim2 = analyticless_test_convergence(dts, prob, LambaEM(), test_dt, trajectories = 300,
-    use_noise_grid = false)
+sim2 = analyticless_test_convergence(
+    dts, prob, LambaEM(), test_dt, trajectories = 300,
+    use_noise_grid = false
+)
 @test abs(sim2.𝒪est[:final] - 0.5) < 0.3
-sim2 = analyticless_test_convergence(dts, prob, EulerHeun(), test_dt, trajectories = 300,
-    use_noise_grid = false)
+sim2 = analyticless_test_convergence(
+    dts, prob, EulerHeun(), test_dt, trajectories = 300,
+    use_noise_grid = false
+)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3
-sim2 = analyticless_test_convergence(dts, prob, LambaEulerHeun(), test_dt,
-    trajectories = 300, use_noise_grid = false)
+sim2 = analyticless_test_convergence(
+    dts, prob, LambaEulerHeun(), test_dt,
+    trajectories = 300, use_noise_grid = false
+)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3
-sim2 = analyticless_test_convergence(dts, prob, RKMil(), test_dt, trajectories = 300,
-    use_noise_grid = false)
+sim2 = analyticless_test_convergence(
+    dts, prob, RKMil(), test_dt, trajectories = 300,
+    use_noise_grid = false
+)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3
 sim2 = analyticless_test_convergence(
     dts, prob, RKMil(interpretation = SciMLBase.AlgorithmInterpretation.Stratonovich),
-    test_dt, trajectories = 300, use_noise_grid = false)
+    test_dt, trajectories = 300, use_noise_grid = false
+)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3
-sim2 = analyticless_test_convergence(dts, prob, WangLi3SMil_A(), test_dt,
-    trajectories = 300, use_noise_grid = false)
+sim2 = analyticless_test_convergence(
+    dts, prob, WangLi3SMil_A(), test_dt,
+    trajectories = 300, use_noise_grid = false
+)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3
-sim2 = analyticless_test_convergence(dts, prob, WangLi3SMil_B(), test_dt,
-    trajectories = 300, use_noise_grid = false)
+sim2 = analyticless_test_convergence(
+    dts, prob, WangLi3SMil_B(), test_dt,
+    trajectories = 300, use_noise_grid = false
+)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3
-sim2 = analyticless_test_convergence(dts, prob, WangLi3SMil_C(), test_dt,
-    trajectories = 300, use_noise_grid = false)
+sim2 = analyticless_test_convergence(
+    dts, prob, WangLi3SMil_C(), test_dt,
+    trajectories = 300, use_noise_grid = false
+)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3
-sim2 = analyticless_test_convergence(dts, prob, WangLi3SMil_D(), test_dt,
-    trajectories = 300, use_noise_grid = false)
+sim2 = analyticless_test_convergence(
+    dts, prob, WangLi3SMil_D(), test_dt,
+    trajectories = 300, use_noise_grid = false
+)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3
-sim2 = analyticless_test_convergence(dts, prob, WangLi3SMil_E(), test_dt,
-    trajectories = 300, use_noise_grid = false)
+sim2 = analyticless_test_convergence(
+    dts, prob, WangLi3SMil_E(), test_dt,
+    trajectories = 300, use_noise_grid = false
+)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3
-sim2 = analyticless_test_convergence(dts, prob, WangLi3SMil_F(), test_dt,
-    trajectories = 300, use_noise_grid = false)
+sim2 = analyticless_test_convergence(
+    dts, prob, WangLi3SMil_F(), test_dt,
+    trajectories = 300, use_noise_grid = false
+)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3
 
 # Test SROCK methods
 println("SROCK methods")
 prob.p .= pmul;
-sim2 = analyticless_test_convergence(dts, prob, SROCK1(), test_dt, trajectories = 100,
-    use_noise_grid = false)
+sim2 = analyticless_test_convergence(
+    dts, prob, SROCK1(), test_dt, trajectories = 100,
+    use_noise_grid = false
+)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3
 sim2 = analyticless_test_convergence(
     dts, prob, SROCK1(interpretation = SciMLBase.AlgorithmInterpretation.Stratonovich),
-    test_dt, trajectories = 300, use_noise_grid = false)
+    test_dt, trajectories = 300, use_noise_grid = false
+)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3
-sim2 = analyticless_test_convergence(dts, prob, SROCKEM(), test_dt, trajectories = 300,
-    use_noise_grid = false)
+sim2 = analyticless_test_convergence(
+    dts, prob, SROCKEM(), test_dt, trajectories = 300,
+    use_noise_grid = false
+)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3
-sim2 = analyticless_test_convergence(dts, prob, SROCKEM(strong_order_1 = false), test_dt,
-    trajectories = 300, use_noise_grid = false)
+sim2 = analyticless_test_convergence(
+    dts, prob, SROCKEM(strong_order_1 = false), test_dt,
+    trajectories = 300, use_noise_grid = false
+)
 @test abs(sim2.𝒪est[:final] - 0.5) < 0.3
-sim2 = analyticless_test_convergence(dts, prob, SKSROCK(), test_dt, trajectories = 300,
-    use_noise_grid = false)
+sim2 = analyticless_test_convergence(
+    dts, prob, SKSROCK(), test_dt, trajectories = 300,
+    use_noise_grid = false
+)
 @test abs(sim2.𝒪est[:final] - 0.5) < 0.3
-sim2 = analyticless_test_convergence(dts, prob, SKSROCK(; post_processing = true), test_dt,
-    trajectories = 300, use_noise_grid = false)
+sim2 = analyticless_test_convergence(
+    dts, prob, SKSROCK(; post_processing = true), test_dt,
+    trajectories = 300, use_noise_grid = false
+)
 @test abs(sim2.𝒪est[:final] - 0.5) < 0.3
 
 # Test Implicit methods
 println("implicit methods")
-sim2 = analyticless_test_convergence(dts, prob, ImplicitEM(), test_dt, trajectories = 300,
-    use_noise_grid = false)
+sim2 = analyticless_test_convergence(
+    dts, prob, ImplicitEM(), test_dt, trajectories = 300,
+    use_noise_grid = false
+)
 @test abs(sim2.𝒪est[:final] - 0.5) < 0.3
-sim2 = analyticless_test_convergence(dts, prob,
+sim2 = analyticless_test_convergence(
+    dts, prob,
     ImplicitEM(symplectic = true, theta = 1 / 2), test_dt,
-    trajectories = 300, use_noise_grid = false)
+    trajectories = 300, use_noise_grid = false
+)
 @test abs(sim2.𝒪est[:final] - 0.5) < 0.3
-sim2 = analyticless_test_convergence(dts, prob, ImplicitEulerHeun(), test_dt,
-    trajectories = 300, use_noise_grid = false)
+sim2 = analyticless_test_convergence(
+    dts, prob, ImplicitEulerHeun(), test_dt,
+    trajectories = 300, use_noise_grid = false
+)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3
-sim2 = analyticless_test_convergence(dts, prob,
+sim2 = analyticless_test_convergence(
+    dts, prob,
     ImplicitEulerHeun(symplectic = true, theta = 1 / 2),
-    test_dt, trajectories = 300, use_noise_grid = false)
+    test_dt, trajectories = 300, use_noise_grid = false
+)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3
-sim2 = analyticless_test_convergence(dts, prob, ISSEM(), test_dt, trajectories = 1000,
-    use_noise_grid = false)
+sim2 = analyticless_test_convergence(
+    dts, prob, ISSEM(), test_dt, trajectories = 1000,
+    use_noise_grid = false
+)
 @test abs(sim2.𝒪est[:final] - 0.5) < 0.35
-sim2 = analyticless_test_convergence(dts, prob, ISSEM(symplectic = true, theta = 1 / 2),
-    test_dt, trajectories = 500, use_noise_grid = false)
+sim2 = analyticless_test_convergence(
+    dts, prob, ISSEM(symplectic = true, theta = 1 / 2),
+    test_dt, trajectories = 500, use_noise_grid = false
+)
 @test abs(sim2.𝒪est[:final] - 0.5) < 0.3
-sim2 = analyticless_test_convergence(dts, prob, ImplicitRKMil(), test_dt,
-    trajectories = 300, use_noise_grid = false)
+sim2 = analyticless_test_convergence(
+    dts, prob, ImplicitRKMil(), test_dt,
+    trajectories = 300, use_noise_grid = false
+)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3
-sim2 = analyticless_test_convergence(dts, prob,
+sim2 = analyticless_test_convergence(
+    dts, prob,
     ImplicitRKMil(symplectic = true, theta = 1 / 2),
-    test_dt, trajectories = 300, use_noise_grid = false)
+    test_dt, trajectories = 300, use_noise_grid = false
+)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3
-sim2 = analyticless_test_convergence(dts, prob,
-    ImplicitRKMil(interpretation = SciMLBase.AlgorithmInterpretation.Stratonovich,
-        symplectic = true, theta = 1 / 2),
-    test_dt, trajectories = 300, use_noise_grid = false)
+sim2 = analyticless_test_convergence(
+    dts, prob,
+    ImplicitRKMil(
+        interpretation = SciMLBase.AlgorithmInterpretation.Stratonovich,
+        symplectic = true, theta = 1 / 2
+    ),
+    test_dt, trajectories = 300, use_noise_grid = false
+)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3
 sim2 = analyticless_test_convergence(
     dts, prob, ISSEulerHeun(), test_dt, trajectories = 300,
-    use_noise_grid = false)
+    use_noise_grid = false
+)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3
-sim2 = analyticless_test_convergence(dts, prob,
+sim2 = analyticless_test_convergence(
+    dts, prob,
     ISSEulerHeun(symplectic = true, theta = 1 / 2),
-    test_dt, trajectories = 300, use_noise_grid = false)
+    test_dt, trajectories = 300, use_noise_grid = false
+)
 @test abs(sim2.𝒪est[:final] - 1.0) < 0.3

--- a/test/events.jl
+++ b/test/events.jl
@@ -8,8 +8,10 @@ using Test
     prob = SDDEProblem(f, g, h, (0.0, 4.0), 0.5; constant_lags = (0.5,))
 
     # event at `t = 3`
-    cb = DiscreteCallback((u, t, integrator) -> t == 3,
-        integrator -> (integrator.u = -integrator.u))
+    cb = DiscreteCallback(
+        (u, t, integrator) -> t == 3,
+        integrator -> (integrator.u = -integrator.u)
+    )
 
     sol = solve(prob, RKMil(), tstops = (3,), callback = cb)
     ts = findall(x -> x == 3, sol.t)

--- a/test/nondiagonal_sparse_noise.jl
+++ b/test/nondiagonal_sparse_noise.jl
@@ -15,7 +15,7 @@ function sir_dde!(du, u, h, p, t)
         du[2] = infection - recovery
         du[3] = recovery
     end
-    nothing
+    return nothing
 end;
 
 # Define a sparse matrix by making a dense matrix and setting some values as not zero
@@ -38,14 +38,14 @@ function sir_delayed_noise!(du, u, h, p, t)
     du[1, 1] = -sqrt(infection)
     du[2, 1] = sqrt(infection)
     du[2, 2] = -sqrt(recovery)
-    du[3, 2] = sqrt(recovery)
+    return du[3, 2] = sqrt(recovery)
 end;
 
 function condition(u, t, integrator) # Event when event_f(u,t) == 0
-    u[2]
+    return u[2]
 end;
 function affect!(integrator)
-    integrator.u[2] = 0.0
+    return integrator.u[2] = 0.0
 end;
 cb = ContinuousCallback(condition, affect!);
 
@@ -56,12 +56,14 @@ t = 0.0:δt:tmax;
 u0 = [990.0, 10.0, 0.0]; # S,I,R
 
 function sir_history(p, t)
-    [1000.0, 0.0, 0.0]
+    return [1000.0, 0.0, 0.0]
 end;
 
 p = [0.05, 10.0, 4.0]; # β,c,τ
 Random.seed!(1234);
 
-prob_sdde = SDDEProblem(sir_dde!, sir_delayed_noise!, u0, sir_history, tspan, p;
-    noise_rate_prototype = A);
+prob_sdde = SDDEProblem(
+    sir_dde!, sir_delayed_noise!, u0, sir_history, tspan, p;
+    noise_rate_prototype = A
+);
 sol_sdde = solve(prob_sdde, LambaEM(), callback = cb);

--- a/test/test_prob_sol.jl
+++ b/test/test_prob_sol.jl
@@ -5,11 +5,11 @@ using Test
 begin
     function hayes_modelf(du, u, h, p, t)
         τ, a, b, c, α, β, γ = p
-        du .= a .* u .+ b .* h(p, t - τ) .+ c
+        return du .= a .* u .+ b .* h(p, t - τ) .+ c
     end
     function hayes_modelg(du, u, h, p, t)
         τ, a, b, c, α, β, γ = p
-        du .= α .* u .+ β .* h(p, t - τ) .+ γ
+        return du .= α .* u .+ β .* h(p, t - τ) .+ γ
     end
     h(p, t) = (ones(1) .+ t)
     tspan = (0.0, 0.1)
@@ -18,10 +18,14 @@ end
 pmul = [1.0, -4.0, -2.0, 10.0, -1.3, -1.2, 1.1]
 padd = [1.0, -4.0, -2.0, 10.0, -0.0, -0.0, 0.1]
 
-prob = @test_nowarn SDDEProblem(hayes_modelf, hayes_modelg, [1.0], h, tspan, pmul;
-    constant_lags = (pmul[1],));
-@test_nowarn SDDEProblem(hayes_modelf, hayes_modelg, h, tspan, padd;
-    constant_lags = (padd[1],));
+prob = @test_nowarn SDDEProblem(
+    hayes_modelf, hayes_modelg, [1.0], h, tspan, pmul;
+    constant_lags = (pmul[1],)
+);
+@test_nowarn SDDEProblem(
+    hayes_modelf, hayes_modelg, h, tspan, padd;
+    constant_lags = (padd[1],)
+);
 
 sol = @test_nowarn solve(prob, EM(), dt = 0.01)
 @test sol.u[end] != zeros(1)
@@ -34,12 +38,14 @@ sol = @test_nowarn solve(prob, LambaEulerHeun(), dt = 0.01)
 sol = @test_nowarn solve(prob, RKMil(), dt = 0.01)
 @test sol.u[end] != zeros(1)
 sol = @test_nowarn solve(
-    prob, RKMil(interpretation = SciMLBase.AlgorithmInterpretation.Stratonovich), dt = 0.01)
+    prob, RKMil(interpretation = SciMLBase.AlgorithmInterpretation.Stratonovich), dt = 0.01
+)
 @test sol.u[end] != zeros(1)
 sol = @test_nowarn solve(prob, RKMilCommute(), dt = 0.01)
 @test sol.u[end] != zeros(1)
 sol = @test_nowarn solve(
-    prob, RKMilCommute(interpretation = SciMLBase.AlgorithmInterpretation.Stratonovich), dt = 0.01)
+    prob, RKMilCommute(interpretation = SciMLBase.AlgorithmInterpretation.Stratonovich), dt = 0.01
+)
 @test sol.u[end] != zeros(1)
 sol = @test_nowarn solve(prob, WangLi3SMil_A(), dt = 0.01)
 @test sol.u[end] != zeros(1)
@@ -87,7 +93,8 @@ prob.p .= pmul;
 sol = @test_nowarn solve(prob, SROCK1(), dt = 0.01)
 @test sol.u[end] != zeros(1)
 sol = @test_nowarn solve(
-    prob, SROCK1(interpretation = SciMLBase.AlgorithmInterpretation.Stratonovich), dt = 0.01)
+    prob, SROCK1(interpretation = SciMLBase.AlgorithmInterpretation.Stratonovich), dt = 0.01
+)
 @test sol.u[end] != zeros(1)
 sol = @test_nowarn solve(prob, SROCKEM(), dt = 0.01)
 @test sol.u[end] != zeros(1)
@@ -114,17 +121,22 @@ sol = @test_nowarn solve(prob, ImplicitEM(symplectic = true, theta = 1 / 2), dt 
 @test sol.u[end] != zeros(1)
 sol = @test_nowarn solve(prob, ImplicitEulerHeun(), dt = 0.01)
 @test sol.u[end] != zeros(1)
-sol = @test_nowarn solve(prob, ImplicitEulerHeun(symplectic = true, theta = 1 / 2),
-    dt = 0.01)
+sol = @test_nowarn solve(
+    prob, ImplicitEulerHeun(symplectic = true, theta = 1 / 2),
+    dt = 0.01
+)
 @test sol.u[end] != zeros(1)
 sol = @test_nowarn solve(prob, ImplicitRKMil(), dt = 0.01)
 @test sol.u[end] != zeros(1)
 sol = @test_nowarn solve(prob, ImplicitRKMil(symplectic = true, theta = 1 / 2), dt = 0.01)
 @test sol.u[end] != zeros(1)
-sol = @test_nowarn solve(prob,
+sol = @test_nowarn solve(
+    prob,
     ImplicitRKMil(
         interpretation = SciMLBase.AlgorithmInterpretation.Stratonovich, symplectic = true,
-        theta = 1 / 2), dt = 0.01)
+        theta = 1 / 2
+    ), dt = 0.01
+)
 @test sol.u[end] != zeros(1)
 sol = @test_nowarn solve(prob, ISSEM(), dt = 0.01)
 @test sol.u[end] != zeros(1)


### PR DESCRIPTION
## Summary
- Updated CI workflow to use `fredrikekre/runic-action@v1` instead of JuliaFormatter
- Removed `.JuliaFormatter.toml` configuration file
- Reformatted all source files with Runic.jl

## Changes
This PR migrates the code formatting from JuliaFormatter with SciMLStyle to Runic.jl. Runic.jl is an opinionated formatter (similar to Go's gofmt) that requires no configuration.

Key differences from JuliaFormatter:
- Explicit `return` statements are added where implicit
- Different indentation and alignment for continuation lines
- Consistent multiline formatting for function arguments

## Test plan
- [ ] CI format check passes with Runic.jl
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)