### PR TITLE
Fix numerical stability in Non-Diagonal Sparse Noise test

### DIFF
--- a/test/nondiagonal_sparse_noise.jl
+++ b/test/nondiagonal_sparse_noise.jl
@@ -27,6 +27,7 @@ A[3, 2] = 1
 A = SparseArrays.sparse(A);
 
 # Make `g` write the sparse matrix values
+# Use max(0, x) to prevent DomainError from sqrt when stochastic dynamics cause negative values
 function sir_delayed_noise!(du, u, h, p, t)
     (S, I, R) = u
     (β, c, τ) = p
@@ -35,10 +36,10 @@ function sir_delayed_noise!(du, u, h, p, t)
     (Sd, Id, Rd) = h(p, t - τ) # Time delayed variables
     Nd = Sd + Id + Rd
     recovery = β * c * Id / Nd * Sd
-    du[1, 1] = -sqrt(infection)
-    du[2, 1] = sqrt(infection)
-    du[2, 2] = -sqrt(recovery)
-    return du[3, 2] = sqrt(recovery)
+    du[1, 1] = -sqrt(max(0.0, infection))
+    du[2, 1] = sqrt(max(0.0, infection))
+    du[2, 2] = -sqrt(max(0.0, recovery))
+    return du[3, 2] = sqrt(max(0.0, recovery))
 end;
 
 function condition(u, t, integrator) # Event when event_f(u,t) == 0


### PR DESCRIPTION
## Summary

- Use `max(0.0, x)` before `sqrt` in the test's noise function to prevent `DomainError` when stochastic dynamics cause infection/recovery values to become negative

This is a standard practice for stochastic SIR models where the noise can cause values to temporarily go negative.

## Related PR

This PR should be merged after https://github.com/SciML/StochasticDiffEq.jl/pull/668 which fixes the `change_t_via_interpolation!` method to support SDDE integrators. Once that is merged and a new version released, this test fix will allow the callback to work correctly.

## Test plan

- [x] Tested locally with the StochasticDiffEq fix - all tests pass
- [ ] CI passes (requires StochasticDiffEq fix first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)